### PR TITLE
Fixes missing techs

### DIFF
--- a/Megamp/history/countries/BAV - Bavaria.txt
+++ b/Megamp/history/countries/BAV - Bavaria.txt
@@ -60,6 +60,7 @@ late_enlightenment_philosophy = 1
 mechanical_production = 1
 military_staff_system = 1
 no_standard = 1
+piston_steam_engine = 1
 post_napoleonic_thought = 1
 practical_steam_engine = 1
 private_banks = 1

--- a/Megamp/history/countries/ENG - United Kingdom.txt
+++ b/Megamp/history/countries/ENG - United Kingdom.txt
@@ -55,6 +55,7 @@ guild_based_production = 1
 late_enlightenment_philosophy = 1
 naval_design_bureaus = 1
 no_standard = 1
+piston_steam_engine = 1
 post_napoleonic_thought = 1
 post_nelsonian_thought = 1
 private_banks = 1

--- a/Megamp/history/countries/FRA - France.txt
+++ b/Megamp/history/countries/FRA - France.txt
@@ -55,6 +55,7 @@ guild_based_production = 1
 late_enlightenment_philosophy = 1
 military_staff_system = 1
 no_standard = 1
+piston_steam_engine = 1
 post_napoleonic_thought = 1
 water_wheel_power = 1
 prestige=46.842

--- a/Megamp/history/countries/NET - Netherlands.txt
+++ b/Megamp/history/countries/NET - Netherlands.txt
@@ -57,6 +57,7 @@ guild_based_production = 1
 hot_blast = 1
 late_enlightenment_philosophy = 1
 no_standard = 1
+piston_steam_engine = 1
 post_napoleonic_thought = 1
 post_nelsonian_thought = 1
 private_banks = 1

--- a/Megamp/history/countries/PLC - Polish-Lithuanian Commonwealth.txt
+++ b/Megamp/history/countries/PLC - Polish-Lithuanian Commonwealth.txt
@@ -62,6 +62,7 @@ hot_blast = 1
 late_enlightenment_philosophy = 1
 military_staff_system = 1
 no_standard = 1
+piston_steam_engine = 1
 post_napoleonic_thought = 1
 practical_steam_engine = 1
 private_banks = 1

--- a/Megamp/history/countries/PRU - Prussia.txt
+++ b/Megamp/history/countries/PRU - Prussia.txt
@@ -57,6 +57,7 @@ guild_based_production = 1
 hot_blast = 1
 late_enlightenment_philosophy = 1
 no_standard = 1
+piston_steam_engine = 1
 post_napoleonic_thought = 1
 practical_steam_engine = 1
 private_banks = 1

--- a/Megamp/history/countries/RUS - Russia.txt
+++ b/Megamp/history/countries/RUS - Russia.txt
@@ -59,6 +59,7 @@ guild_based_production = 1
 late_enlightenment_philosophy = 1
 mechanical_production = 1
 no_standard = 1
+piston_steam_engine = 1
 post_napoleonic_thought = 1
 practical_steam_engine = 1
 private_banks = 1

--- a/Megamp/history/countries/SCA - Scandinavia.txt
+++ b/Megamp/history/countries/SCA - Scandinavia.txt
@@ -62,6 +62,7 @@ guild_based_production = 1
 late_enlightenment_philosophy = 1
 military_staff_system = 1
 no_standard = 1
+piston_steam_engine = 1
 post_napoleonic_thought = 1
 post_nelsonian_thought = 1
 private_banks = 1

--- a/Megamp/history/countries/SPA - Spain.txt
+++ b/Megamp/history/countries/SPA - Spain.txt
@@ -62,6 +62,7 @@ late_enlightenment_philosophy = 1
 mechanical_production = 1
 military_staff_system = 1
 no_standard = 1
+piston_steam_engine = 1
 post_napoleonic_thought = 1
 practical_steam_engine = 1
 private_banks = 1

--- a/Megamp/history/countries/TUR - Ottoman Empire.txt
+++ b/Megamp/history/countries/TUR - Ottoman Empire.txt
@@ -61,6 +61,7 @@ late_enlightenment_philosophy = 1
 malthusian_thought = 1
 mechanical_production = 1
 no_standard = 1
+piston_steam_engine = 1
 post_napoleonic_thought = 1
 practical_steam_engine = 1
 private_banks = 1

--- a/Megamp/history/countries/USA - USA.txt
+++ b/Megamp/history/countries/USA - USA.txt
@@ -57,6 +57,7 @@ introspectionism = 1
 late_enlightenment_philosophy = 1
 malthusian_thought = 1
 no_standard = 1
+piston_steam_engine = 1
 private_banks = 1
 publishing_industry = 1
 romanticism = 1


### PR DESCRIPTION
Everybody will lose any second-level techs they were given at first as those don't appear until 1825. The first-level industrial power tech "water_wheel_power" isn't in HPM, so I gave everyone "piston_steam_engine" if you had the water wheel tech.

Closes #3 