### PR TITLE
Hawaii annexation event

### DIFF
--- a/Megamp/decisions/Megamp Decisions.txt
+++ b/Megamp/decisions/Megamp Decisions.txt
@@ -1,0 +1,26 @@
+political_decisions = {
+	annex_hawaii = {
+		potential = {
+			NOT = {
+				has_country_flag = hawaii_annexed
+			}
+			exists = HAW
+			is_sphere_leader_of = HAW
+			HAW = { ai = yes }
+		}
+		
+		allow = {
+			nationalism_n_imperialism = 1
+			is_sphere_leader_of = HAW
+		}
+		
+		effect = {
+			HAW_658 = {
+				add_core = THIS
+			}
+			prestige = 2
+			inherit = HAW
+			set_country_flag = hawaii_annexed
+		}
+	}
+}


### PR DESCRIPTION
Replaces the vanilla Hawaii annexation event to allow for the sphere owner to annex Hawaii after N&I is researched. Future custom decisions can go in this file.

Closes #17.