### PR TITLE
Pop screen crash fix

### DIFF
--- a/Megamp/common/pop_types.txt
+++ b/Megamp/common/pop_types.txt
@@ -748,7 +748,6 @@ assimilation_chance =
         OR = {
             location = { continent = north_america }
             location = { continent = south_america }
-            location = { continent = australia_new_zealand }
         }
     }
 
@@ -835,7 +834,6 @@ assimilation_chance =
         OR = {
             location = { continent = north_america }
             location = { continent = south_america }
-            location = { continent = australia_new_zealand }
         }
     }
 
@@ -852,7 +850,6 @@ assimilation_chance =
         OR = {
             location = { continent = north_america }
             location = { continent = south_america }
-            location = { continent = australia_new_zealand }
         }
     }
 

--- a/Megamp/poptypes/aristocrats.txt
+++ b/Megamp/poptypes/aristocrats.txt
@@ -150,7 +150,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -167,7 +167,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -233,13 +233,8 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.7
-        terrain = savanna
-    }
-
-    modifier = {
         factor = 0.8
-        terrain = dryhills
+        terrain = hills
     }
 
     modifier = {
@@ -254,7 +249,7 @@ migration_target = {
 
     modifier = {
         factor = 0.6
-        terrain = montane_forest
+        terrain = forest
     }
 
     modifier = {
@@ -264,27 +259,17 @@ migration_target = {
 
     modifier = {
         factor = 0.5
-        terrain = semidesert
-    }
-
-    modifier = {
-        factor = 0.5
-        terrain = boreal
+        terrain = woods
     }
 
     modifier = {
         factor = 0.1
-        terrain = small_island
+        terrain = coastal_desert
     }
 
     modifier = {
         factor = 0.01
-        terrain = coral_island
-    }
-
-    modifier = {
-        factor = 0.05
-        terrain = desert
+        terrain = farmlands
     }
 
     modifier = {
@@ -296,11 +281,6 @@ migration_target = {
     modifier = {
         factor = 0.05
         terrain = arctic
-    }
-
-    modifier = {
-        factor = 0.05
-        terrain = montane_tundra
     }
 
     modifier = {
@@ -319,11 +299,9 @@ migration_target = {
         OR = {
             terrain = desert
             terrain = arctic
-            terrain = semidesert
-            terrain = boreal
-            terrain = small_island
-            terrain = montane_tundra
-            terrain = coral_island
+            terrain = coastal_desert
+            terrain = woods
+            terrain = farmlands
         }
     }
     modifier = {
@@ -347,11 +325,9 @@ promote_to =
             OR = {
                 terrain = desert
                 terrain = arctic
-                terrain = semidesert
-                terrain = boreal
-                terrain = small_island
-                terrain = montane_tundra
-                terrain = coral_island
+                terrain = coastal_desert
+                terrain = woods
+                terrain = farmlands
             }
         }
         modifier = {

--- a/Megamp/poptypes/artisans.txt
+++ b/Megamp/poptypes/artisans.txt
@@ -132,7 +132,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -149,7 +149,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -253,13 +253,8 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.7
-        terrain = savanna
-    }
-
-    modifier = {
         factor = 0.8
-        terrain = dryhills
+        terrain = hills
     }
 
     modifier = {
@@ -274,7 +269,7 @@ migration_target = {
 
     modifier = {
         factor = 0.6
-        terrain = montane_forest
+        terrain = forest
     }
 
     modifier = {
@@ -283,23 +278,13 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.5
-        terrain = semidesert
-    }
-
-    modifier = {
-        factor = 0.5
-        terrain = boreal
-    }
-
-    modifier = {
         factor = 0.1
-        terrain = small_island
+        terrain = coastal_desert
     }
 
     modifier = {
         factor = 0.01
-        terrain = coral_island
+        terrain = farmlands
     }
 
     modifier = {
@@ -320,7 +305,7 @@ migration_target = {
 
     modifier = {
         factor = 0.05
-        terrain = montane_tundra
+        terrain = woods
     }
 
     modifier = {
@@ -339,11 +324,9 @@ migration_target = {
         OR = {
             terrain = desert
             terrain = arctic
-            terrain = semidesert
-            terrain = boreal
-            terrain = small_island
-            terrain = montane_tundra
-            terrain = coral_island
+            terrain = coastal_desert
+            terrain = woods
+            terrain = farmlands
         }
     }
     modifier = {
@@ -939,11 +922,9 @@ promote_to =
             OR = {
                 terrain = desert
                 terrain = arctic
-                terrain = semidesert
-                terrain = boreal
-                terrain = small_island
-                terrain = montane_tundra
-                terrain = coral_island
+                terrain = coastal_desert
+                terrain = woods
+                terrain = farmlands
             }
         }
         modifier = {

--- a/Megamp/poptypes/bureaucrats.txt
+++ b/Megamp/poptypes/bureaucrats.txt
@@ -159,7 +159,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -176,7 +176,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -242,13 +242,8 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.7
-        terrain = savanna
-    }
-
-    modifier = {
         factor = 0.8
-        terrain = dryhills
+        terrain = hills
     }
 
     modifier = {
@@ -263,7 +258,7 @@ migration_target = {
 
     modifier = {
         factor = 0.6
-        terrain = montane_forest
+        terrain = forest
     }
 
     modifier = {
@@ -273,22 +268,17 @@ migration_target = {
 
     modifier = {
         factor = 0.5
-        terrain = semidesert
-    }
-
-    modifier = {
-        factor = 0.5
-        terrain = boreal
+        terrain = woods
     }
 
     modifier = {
         factor = 0.1
-        terrain = small_island
+        terrain = coastal_desert
     }
 
     modifier = {
         factor = 0.01
-        terrain = coral_island
+        terrain = farmlands
     }
 
     modifier = {
@@ -309,7 +299,7 @@ migration_target = {
 
     modifier = {
         factor = 0.05
-        terrain = montane_tundra
+        terrain = woods
     }
 
     modifier = {
@@ -328,11 +318,9 @@ migration_target = {
         OR = {
             terrain = desert
             terrain = arctic
-            terrain = semidesert
-            terrain = boreal
-            terrain = small_island
-            terrain = montane_tundra
-            terrain = coral_island
+            terrain = coastal_desert
+            terrain = woods
+            terrain = farmlands
         }
     }
     modifier = {
@@ -356,11 +344,9 @@ promote_to =
             OR = {
                 terrain = desert
                 terrain = arctic
-                terrain = semidesert
-                terrain = boreal
-                terrain = small_island
-                terrain = montane_tundra
-                terrain = coral_island
+                terrain = coastal_desert
+                terrain = woods
+                terrain = farmlands
             }
         }
         modifier = {

--- a/Megamp/poptypes/capitalists.txt
+++ b/Megamp/poptypes/capitalists.txt
@@ -133,7 +133,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -150,7 +150,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -224,13 +224,8 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.7
-        terrain = savanna
-    }
-
-    modifier = {
         factor = 0.8
-        terrain = dryhills
+        terrain = hills
     }
 
     modifier = {
@@ -245,7 +240,7 @@ migration_target = {
 
     modifier = {
         factor = 0.6
-        terrain = montane_forest
+        terrain = forest
     }
 
     modifier = {
@@ -254,23 +249,13 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.5
-        terrain = semidesert
-    }
-
-    modifier = {
-        factor = 0.5
-        terrain = boreal
-    }
-
-    modifier = {
         factor = 0.1
-        terrain = small_island
+        terrain = coastal_desert
     }
 
     modifier = {
         factor = 0.01
-        terrain = coral_island
+        terrain = farmlands
     }
 
     modifier = {
@@ -291,7 +276,7 @@ migration_target = {
 
     modifier = {
         factor = 0.05
-        terrain = montane_tundra
+        terrain = woods
     }
 
     modifier = {
@@ -310,11 +295,9 @@ migration_target = {
         OR = {
             terrain = desert
             terrain = arctic
-            terrain = semidesert
-            terrain = boreal
-            terrain = small_island
-            terrain = montane_tundra
-            terrain = coral_island
+            terrain = coastal_desert
+            terrain = woods
+            terrain = farmlands
         }
     }
     modifier = {

--- a/Megamp/poptypes/clergymen.txt
+++ b/Megamp/poptypes/clergymen.txt
@@ -163,7 +163,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -180,7 +180,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -257,13 +257,8 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.7
-        terrain = savanna
-    }
-
-    modifier = {
         factor = 0.8
-        terrain = dryhills
+        terrain = hills
     }
 
     modifier = {
@@ -278,7 +273,7 @@ migration_target = {
 
     modifier = {
         factor = 0.6
-        terrain = montane_forest
+        terrain = forest
     }
 
     modifier = {
@@ -287,23 +282,13 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.5
-        terrain = semidesert
-    }
-
-    modifier = {
-        factor = 0.5
-        terrain = boreal
-    }
-
-    modifier = {
         factor = 0.1
-        terrain = small_island
+        terrain = coastal_desert
     }
 
     modifier = {
         factor = 0.01
-        terrain = coral_island
+        terrain = farmlands
     }
 
     modifier = {
@@ -324,7 +309,7 @@ migration_target = {
 
     modifier = {
         factor = 0.05
-        terrain = montane_tundra
+        terrain = woods
     }
 
     modifier = {
@@ -343,11 +328,9 @@ migration_target = {
         OR = {
             terrain = desert
             terrain = arctic
-            terrain = semidesert
-            terrain = boreal
-            terrain = small_island
-            terrain = montane_tundra
-            terrain = coral_island
+            terrain = coastal_desert
+            terrain = woods
+            terrain = farmlands
         }
     }
     modifier = {

--- a/Megamp/poptypes/clerks.txt
+++ b/Megamp/poptypes/clerks.txt
@@ -136,7 +136,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -153,7 +153,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -254,13 +254,8 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.7
-        terrain = savanna
-    }
-
-    modifier = {
         factor = 0.8
-        terrain = dryhills
+        terrain = hills
     }
 
     modifier = {
@@ -275,7 +270,7 @@ migration_target = {
 
     modifier = {
         factor = 0.6
-        terrain = montane_forest
+        terrain = forest
     }
 
     modifier = {
@@ -285,22 +280,17 @@ migration_target = {
 
     modifier = {
         factor = 0.5
-        terrain = semidesert
-    }
-
-    modifier = {
-        factor = 0.5
-        terrain = boreal
+        terrain = woods
     }
 
     modifier = {
         factor = 0.1
-        terrain = small_island
+        terrain = coastal_desert
     }
 
     modifier = {
         factor = 0.01
-        terrain = coral_island
+        terrain = farmlands
     }
 
     modifier = {
@@ -320,11 +310,6 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.05
-        terrain = montane_tundra
-    }
-
-    modifier = {
         factor = 1.05
         NOT = { country = { any_owned_province = { is_colonial = yes } } }
         country = { penal_system = colonial_transportation }
@@ -340,11 +325,9 @@ migration_target = {
         OR = {
             terrain = desert
             terrain = arctic
-            terrain = semidesert
-            terrain = boreal
-            terrain = small_island
-            terrain = montane_tundra
-            terrain = coral_island
+            terrain = coastal_desert
+            terrain = woods
+            terrain = farmlands
         }
     }
     modifier = {
@@ -814,11 +797,9 @@ promote_to =
             OR = {
                 terrain = desert
                 terrain = arctic
-                terrain = semidesert
-                terrain = boreal
-                terrain = small_island
-                terrain = montane_tundra
-                terrain = coral_island
+                terrain = coastal_desert
+                terrain = woods
+                terrain = farmlands
             }
         }
         modifier = {

--- a/Megamp/poptypes/craftsmen.txt
+++ b/Megamp/poptypes/craftsmen.txt
@@ -121,7 +121,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -138,7 +138,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -244,13 +244,8 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.7
-        terrain = savanna
-    }
-
-    modifier = {
         factor = 0.8
-        terrain = dryhills
+        terrain = hills
     }
 
     modifier = {
@@ -265,7 +260,7 @@ migration_target = {
 
     modifier = {
         factor = 0.6
-        terrain = montane_forest
+        terrain = forest
     }
 
     modifier = {
@@ -274,23 +269,13 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.5
-        terrain = semidesert
-    }
-
-    modifier = {
-        factor = 0.5
-        terrain = boreal
-    }
-
-    modifier = {
         factor = 0.1
-        terrain = small_island
+        terrain = coastal_desert
     }
 
     modifier = {
         factor = 0.01
-        terrain = coral_island
+        terrain = farmlands
     }
 
     modifier = {
@@ -311,7 +296,7 @@ migration_target = {
 
     modifier = {
         factor = 0.05
-        terrain = montane_tundra
+        terrain = woods
     }
 
     modifier = {
@@ -330,11 +315,9 @@ migration_target = {
         OR = {
             terrain = desert
             terrain = arctic
-            terrain = semidesert
-            terrain = boreal
-            terrain = small_island
-            terrain = montane_tundra
-            terrain = coral_island
+            terrain = coastal_desert
+            terrain = woods
+            terrain = farmlands
         }
     }
     modifier = {

--- a/Megamp/poptypes/farmers.txt
+++ b/Megamp/poptypes/farmers.txt
@@ -121,7 +121,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -138,7 +138,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -243,13 +243,8 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.7
-        terrain = savanna
-    }
-
-    modifier = {
         factor = 0.8
-        terrain = dryhills
+        terrain = hills
     }
 
     modifier = {
@@ -264,7 +259,7 @@ migration_target = {
 
     modifier = {
         factor = 0.6
-        terrain = montane_forest
+        terrain = forest
     }
 
     modifier = {
@@ -273,23 +268,13 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.5
-        terrain = semidesert
-    }
-
-    modifier = {
-        factor = 0.5
-        terrain = boreal
-    }
-
-    modifier = {
         factor = 0.1
-        terrain = small_island
+        terrain = coastal_desert
     }
 
     modifier = {
         factor = 0.01
-        terrain = coral_island
+        terrain = farmlands
     }
 
     modifier = {
@@ -310,7 +295,7 @@ migration_target = {
 
     modifier = {
         factor = 0.05
-        terrain = montane_tundra
+        terrain = woods
     }
 
     modifier = {
@@ -329,11 +314,9 @@ migration_target = {
         OR = {
             terrain = desert
             terrain = arctic
-            terrain = semidesert
-            terrain = boreal
-            terrain = small_island
-            terrain = montane_tundra
-            terrain = coral_island
+            terrain = coastal_desert
+            terrain = woods
+            terrain = farmlands
         }
     }
     modifier = {

--- a/Megamp/poptypes/labourers.txt
+++ b/Megamp/poptypes/labourers.txt
@@ -122,7 +122,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -139,7 +139,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -244,13 +244,8 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.7
-        terrain = savanna
-    }
-
-    modifier = {
         factor = 0.8
-        terrain = dryhills
+        terrain = hills
     }
 
     modifier = {
@@ -265,7 +260,7 @@ migration_target = {
 
     modifier = {
         factor = 0.6
-        terrain = montane_forest
+        terrain = forest
     }
 
     modifier = {
@@ -274,23 +269,13 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.5
-        terrain = semidesert
-    }
-
-    modifier = {
-        factor = 0.5
-        terrain = boreal
-    }
-
-    modifier = {
         factor = 0.1
-        terrain = small_island
+        terrain = coastal_desert
     }
 
     modifier = {
         factor = 0.01
-        terrain = coral_island
+        terrain = farmlands
     }
 
     modifier = {
@@ -311,7 +296,7 @@ migration_target = {
 
     modifier = {
         factor = 0.05
-        terrain = montane_tundra
+        terrain = woods
     }
 
     modifier = {
@@ -330,11 +315,9 @@ migration_target = {
         OR = {
             terrain = desert
             terrain = arctic
-            terrain = semidesert
-            terrain = boreal
-            terrain = small_island
-            terrain = montane_tundra
-            terrain = coral_island
+            terrain = coastal_desert
+            terrain = woods
+            terrain = farmlands
         }
     }
     modifier = {

--- a/Megamp/poptypes/officers.txt
+++ b/Megamp/poptypes/officers.txt
@@ -153,7 +153,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -170,7 +170,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -239,13 +239,8 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.7
-        terrain = savanna
-    }
-
-    modifier = {
         factor = 0.8
-        terrain = dryhills
+        terrain = hills
     }
 
     modifier = {
@@ -260,7 +255,7 @@ migration_target = {
 
     modifier = {
         factor = 0.6
-        terrain = montane_forest
+        terrain = forest
     }
 
     modifier = {
@@ -269,23 +264,13 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.5
-        terrain = semidesert
-    }
-
-    modifier = {
-        factor = 0.5
-        terrain = boreal
-    }
-
-    modifier = {
         factor = 0.1
-        terrain = small_island
+        terrain = coastal_desert
     }
 
     modifier = {
         factor = 0.01
-        terrain = coral_island
+        terrain = farmlands
     }
 
     modifier = {
@@ -306,7 +291,7 @@ migration_target = {
 
     modifier = {
         factor = 0.05
-        terrain = montane_tundra
+        terrain = woods
     }
 
     modifier = {
@@ -325,11 +310,9 @@ migration_target = {
         OR = {
             terrain = desert
             terrain = arctic
-            terrain = semidesert
-            terrain = boreal
-            terrain = small_island
-            terrain = montane_tundra
-            terrain = coral_island
+            terrain = coastal_desert
+            terrain = woods
+            terrain = farmlands
         }
     }
     modifier = {

--- a/Megamp/poptypes/soldiers.txt
+++ b/Megamp/poptypes/soldiers.txt
@@ -140,7 +140,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -157,7 +157,7 @@ country_migration_target = {
         OR = {
             capital_scope = { is_colonial = no continent = north_america }
             capital_scope = { is_colonial = no continent = south_america }
-            capital_scope = { is_colonial = no continent = australia_new_zealand }
+            capital_scope = { is_colonial = no continent = oceania }
         }
         OR = {
             government = democracy
@@ -226,13 +226,8 @@ migration_target = {
     }
 
     modifier = {
-        factor = 0.7
-        terrain = savanna
-    }
-
-    modifier = {
         factor = 0.8
-        terrain = dryhills
+        terrain = hills
     }
 
     modifier = {
@@ -247,7 +242,7 @@ migration_target = {
 
     modifier = {
         factor = 0.6
-        terrain = montane_forest
+        terrain = forest
     }
 
     modifier = {
@@ -257,27 +252,17 @@ migration_target = {
 
     modifier = {
         factor = 0.5
-        terrain = semidesert
-    }
-
-    modifier = {
-        factor = 0.5
-        terrain = boreal
+        terrain = woods
     }
 
     modifier = {
         factor = 0.1
-        terrain = small_island
+        terrain = coastal_desert
     }
 
     modifier = {
         factor = 0.01
-        terrain = coral_island
-    }
-
-    modifier = {
-        factor = 0.05
-        terrain = desert
+        terrain = farmlands
     }
 
     modifier = {
@@ -289,11 +274,6 @@ migration_target = {
     modifier = {
         factor = 0.05
         terrain = arctic
-    }
-
-    modifier = {
-        factor = 0.05
-        terrain = montane_tundra
     }
 
     modifier = {
@@ -312,11 +292,9 @@ migration_target = {
         OR = {
             terrain = desert
             terrain = arctic
-            terrain = semidesert
-            terrain = boreal
-            terrain = small_island
-            terrain = montane_tundra
-            terrain = coral_island
+            terrain = coastal_desert
+            terrain = woods
+            terrain = farmlands
         }
     }
     modifier = {


### PR DESCRIPTION
Fixes the crash when mousing over pops' cultures. HPM imported files had referenced HPM meme-terrains as well as the HPM-specific regions which was causing crashes. Some cultures are unable to assimilate; this may be an issue to fix later.

Closes #24.