### PR TITLE
Update Sweden.txt

### DIFF
--- a/Megamp/history/pops/1836.1.1/Sweden.txt
+++ b/Megamp/history/pops/1836.1.1/Sweden.txt
@@ -706,7 +706,7 @@
 	{
 		culture = swedish
 		religion = catholic
-		size= 863
+		size= 8863
 	}
 
 	clergymen=


### PR DESCRIPTION
Spawned 8k artisans in Scandinavian Stockholm because they were brutally murdered when tsea decolonized Micronesia.