### PR TITLE
UK flavor & fixes

### DIFF
--- a/Megamp/decisions/ENG.txt
+++ b/Megamp/decisions/ENG.txt
@@ -1,0 +1,1358 @@
+political_decisions = {
+	repeal_the_corn_laws = {
+		potential = {
+			OR = {
+				tag = ENG
+				tag = ENL
+			}
+			has_country_flag = great_irish_famine
+			NOT = {
+				has_country_flag = corn_laws_repealed_flag
+			}
+		}
+		allow = {
+			average_militancy = 2
+		}
+
+		effect = {
+			add_country_modifier = {
+				name = corn_laws_repealed
+				duration = 3650
+			}
+			any_pop = {
+				militancy = -1
+				consciousness = 1
+			}
+			set_country_flag = corn_laws_repealed_flag
+		}
+	}
+	crown_empress_of_india = {
+		picture = crown_empress_of_india
+		news = yes
+		news_desc_long = "empress_of_india_NEWS_LONG"
+		news_desc_medium = "empress_of_india_NEWS_MEDIUM"
+		news_desc_short = "empress_of_india_NEWS_SHORT"
+		potential = {
+			tag = ENG
+			OR = {
+				government = hms_government
+				government = prussian_constitutionalism
+				government = absolute_monarchy
+			}
+			NOT = {
+				has_country_flag = empress_of_india
+			}
+		}
+		allow = {
+			nationalism_n_imperialism = 1
+			prestige = 40
+			owns = 1305
+			owns = 1311
+			owns = 1257
+			owns = 1291
+			owns = 1236
+			owns = 1297
+			owns = 1227
+		}
+		effect = {
+			prestige = 20
+			any_pop = {
+				militancy = -1
+			}
+			HND = {
+				government = colonial_company
+			}
+			set_country_flag = empress_of_india
+		}
+	}
+
+	found_the_bbc = {
+		picture = found_the_bbc
+		potential = {
+			OR = {
+				tag = ENG
+				tag = ENL
+			}
+			year = 1900
+			NOT = {
+				has_country_flag = we_are_live_from_london
+			}
+		}
+
+		allow = {
+			invention = national_radio_networks
+		}
+
+		effect = {
+			any_country = {
+				relation = {
+					who = THIS
+					value = 5
+				}
+			}
+			any_pop = {
+				militancy = -0.5
+			}
+			prestige = 10
+			set_country_flag = we_are_live_from_london
+		}
+	}
+	the_scotland_yard = {
+		potential = {
+			OR = {
+				tag = ENG
+				tag = ENL
+			}
+			NOT = {
+				has_country_flag = elementary_my_dear_watson # I know, he never says it in the books, yadiyadi.
+			}
+		}
+
+		allow = {
+			realism = 1
+		}
+
+		effect = {
+			add_country_modifier = {
+				name = the_yard
+				duration = -1
+			}
+			set_country_flag = elementary_my_dear_watson
+		}
+	}
+	
+	ionian_islands_question = {
+		picture = ionian_islands_question
+		potential = {
+			OR = {
+				tag = ENG
+				tag = ENL
+			}
+			year = 1860
+			ION = {
+				vassal_of = THIS
+				ai = yes
+			}
+			GRE = { exists = yes }
+		}
+		
+		allow = {
+			state_n_government = 1
+			war = no
+		}
+		
+		effect = {
+			random_country = {
+				limit = {
+					tag = GRE
+					exists = yes
+				}
+				relation = { who = THIS value = 100 }
+				inherit = ION
+				THIS = {
+					diplomatic_influence = { who = GRE value = 100 }
+					any_owned = {
+						limit = { is_core = ION }
+						secede_province = ION
+					}
+				}
+				ION = { all_core = { remove_core = ION } }
+			}
+			prestige = 10
+			badboy = -4
+		}
+		
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = {
+					OR = {
+						AND = {
+							year = 1864
+							month = 4
+						}
+						year = 1865
+					}
+				}
+			}
+			modifier = {
+				factor = 0
+				truce_with = GRE
+			}
+		}
+	}
+
+	create_rhodesia = {
+		picture = rhodesia_charter
+		alert = no
+		potential = {
+			any_owned_province = { is_core = RHO }
+			RHO = { exists = no }
+			NOT = {
+				capital_scope = { continent = africa } 
+				capital_scope = { continent = west_africa } 
+				capital_scope = { continent = central_africa } 
+				capital_scope = { continent = east_africa } 
+				capital_scope = { continent = south_west_africa }
+			}
+			NOT = { has_country_flag = post_colonial_country }
+			primary_culture = british
+			civilized = yes
+			revolution_n_counterrevolution = 1
+		}
+		
+		allow = {
+			war = no
+			SAF = { exists = yes }
+			RHO = {
+				all_core = {
+					OR = {
+						owned_by = THIS
+						owner = {
+							in_sphere = THIS
+							OR = { is_vassal = no vassal_of = THIS }
+						}
+					}
+				}
+			}
+		}
+		
+		effect = {
+			prestige = 3
+			RHO = { set_country_flag = post_colonial_country }
+			RHO = { government = dominion all_core = { remove_core = ENG } }
+			ZAM = { all_core = { remove_core = RHO } }
+			any_owned = { limit = { is_core = RHO } secede_province = RHO }
+			create_vassal = RHO
+			create_alliance = RHO
+			diplomatic_influence = { who = RHO value = 400 }	
+		}
+		
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				NOT = { year = 1923 }
+			}
+		}
+	}
+	
+	rhodesia_charter = {
+		potential = {
+			tag = ENG
+			owns = 2068
+			owns = 2069
+			owns = 2070
+			owns = 2071
+			owns = 2072
+			owns = 2073
+			owns = 2635
+			NOT = { has_country_flag = ian_would_be_proud }
+		}
+		
+		allow = { invention = mission_to_civilize }
+		
+		effect = {
+			prestige = 10
+			ENG_2068 = { add_core = RHO }
+			2068 = {
+				change_province_name = "Salisbury"
+				any_pop = { limit = { type = soldiers culture = british } pop_type = farmers }
+				state_scope = {
+					change_region_name = "Southern Rhodesia"
+					any_owned = {
+						add_core = RHO
+					}
+					any_pop = { limit = { type = farmers culture = british } reduce_pop = 2 }
+				}
+			}
+			2073 = {
+				change_province_name = "Fort Victoria"
+				any_pop = { limit = { type = farmers culture = british } reduce_pop = 2 }
+				state_scope = {
+					change_region_name = "Southern Rhodesia"
+					any_owned = { add_core = RHO }
+				}
+			}
+			2072 = { change_province_name = "Wankie" }
+			ENG_2071 = { add_core = RHO }
+			ENG_2014 = { add_core = RHO }
+			ENG_2016 = { add_core = RHO }
+			2015 = { secede_province = THIS	any_pop = { literacy = -0.99 }	}
+			2013 = { secede_province = THIS	any_pop = { literacy = -0.99 }	}
+			2014 = { secede_province = THIS any_pop = { literacy = -0.99 }	}
+			2012 = { secede_province = THIS	any_pop = { literacy = -0.99 }	}
+			790 = { secede_province = THIS any_pop = { literacy = -0.99 }	}
+			2017 = { secede_province = THIS	any_pop = { literacy = -0.99 }	}
+			2016 = { secede_province = THIS	any_pop = { literacy = -0.99 }	}
+			2018 = { secede_province = THIS	any_pop = { literacy = -0.99 }	}
+			2067 = { secede_province = THIS any_pop = { literacy = -0.99 } }
+			2066 = { secede_province = THIS any_pop = { literacy = -0.99 } }
+			any_owned = { limit = { is_core = RHO }
+				add_province_modifier = {
+					name = colonial_exploitation
+					duration = 3650
+				}
+				add_province_modifier = {
+					name = colonial_recruitment
+					duration = 1825
+				}
+			}
+			RHO = { all_core = { remove_core = MAT } }
+			set_country_flag = ian_would_be_proud
+		}
+	}
+	
+	treaty_of_heligoland = {
+		picture = the_heligoland_question
+		potential = {
+			tag = ENG
+			533 = { owned_by = ENG }
+			year = 1881
+			OR = {
+				GER = {
+					exists = yes
+					any_owned_province = {
+						OR = {
+							continent = central_africa
+							AND = {
+								continent = east_africa
+								NOT = { is_core = ETH }
+							}
+							AND = {
+								continent = west_africa
+								NOT = { is_core = CMR }
+							}
+							continent = africa
+						}
+						is_colonial = yes
+						OR = {
+							any_neighbor_province = { owned_by = THIS }
+							port = yes
+						}
+					}
+				}
+				GCF = {
+					exists = yes
+					any_owned_province = {
+						OR = {
+							continent = central_africa
+							AND = {
+								continent = east_africa
+								NOT = { is_core = ETH }
+							}
+							AND = {
+								continent = west_africa
+								NOT = { is_core = CMR }
+							}
+							continent = africa
+						}
+						is_colonial = yes
+						OR = {
+							any_neighbor_province = { owned_by = THIS }
+							port = yes
+						}
+					}
+				}
+			}
+			NOT = { has_country_flag = treaty_of_heligoland }
+		}
+
+		allow = {
+			NOT = { any_greater_power = { war_with = THIS } }
+			NOT = { government = fascist_dictatorship }
+			NOT = { government = proletarian_dictatorship }
+			2013 = { empty = no }
+			2015 = { empty = no }
+			OR = {
+				GER = {
+					exists = yes
+					NOT = { war_with = THIS }
+				}
+				GCF = {
+					exists = yes
+					NOT = { war_with = THIS }
+				}
+			}
+		}
+
+		effect = {
+			set_country_flag = treaty_of_heligoland
+			badboy = -1
+			random_country = {
+				limit = {
+					exists = yes
+					OR = {
+						tag = GER
+						tag = GCF
+					}
+				}
+				country_event = 33006
+			}
+		}
+
+		ai_will_do = { factor = 1 }
+	}
+
+	simla_convention = {
+		picture = treaty_signing
+		potential = {
+			OR = {
+				tag = ENG
+				tag = ENL
+			}
+			TIB = {
+				neighbour = THIS
+				is_vassal = no
+			}
+			NOT = {	has_country_flag = simla_convention }
+		}
+
+		allow = {
+			war = no
+			TIB = {
+				is_vassal = no
+				war = no
+			}
+		}
+
+		effect = {
+			set_country_flag = simla_convention
+			TIB = { country_event = 131711 }
+		}
+
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	trucial_protectorate = {
+		picture = map_arabia
+		potential = {
+			ABU = {
+				ai = yes
+				in_sphere = THIS
+				government = absolute_monarchy
+			}
+			revolution_n_counterrevolution = 1
+			NOT = { has_global_flag = created_trucial_protectorate }
+		}
+		
+		allow = {
+			war = no
+			ABU = {
+				war = no
+				in_sphere = THIS
+				#relation = { who = THIS value = 150 }
+			}
+			mass_politics = 1
+		}
+		
+		effect = {
+			set_global_flag = created_trucial_protectorate
+			prestige = 5
+			create_vassal = ABU
+		}
+	}
+	
+	aden_protectorate = {
+		picture = aden_protectorate
+		potential = {
+			NOT = { is_culture_group = arab }
+			OR = {
+				any_owned_province = { is_core = LHJ }
+				any_owned_province = { is_core = FDL }
+				any_owned_province = { is_core = KTH }
+				any_owned_province = { is_core = MHR }
+				is_sphere_leader_of = LHJ
+				is_sphere_leader_of = FDL
+				is_sphere_leader_of = KTH
+				is_sphere_leader_of = MHR
+			}
+			NOT = { has_global_flag = created_aden_protectorate }
+		}
+		
+		allow = {
+			war = no
+			OR = {
+				LHJ = { exists = no }
+				owns = 1412
+			}
+			1173 = {
+				OR = {
+					owned_by = THIS
+					owner = { in_sphere = THIS }
+					owner = { vassal_of = THIS }
+					KTH = { exists = no }
+				}
+			}
+			1175 = {
+				OR = {
+					owned_by = THIS
+					owner = { in_sphere = THIS }
+					owner = { vassal_of = THIS }
+					MHR = { exists = no }
+				}
+			}
+			1176 = {
+				OR = {
+					owned_by = THIS
+					owner = { in_sphere = THIS }
+					owner = { vassal_of = THIS }
+					FDL = { exists = no }
+				}
+			}
+			1177 = {
+				OR = {
+					owned_by = THIS
+					owner = { in_sphere = THIS }
+					owner = { vassal_of = THIS }
+					MHR = { exists = no }
+				}
+			}
+			YEM = { exists = no }
+		}
+		
+		effect = {
+			set_global_flag = created_aden_protectorate
+			badboy = -3
+			prestige = 10
+			any_country = {
+				limit = {
+					OR = {
+						in_sphere = THIS
+						vassal_of = THIS
+					}
+					exists = yes
+					OR = {
+						tag = KTH
+						tag = LHJ
+						tag = FDL
+						tag = MHR
+					}
+					ai = yes
+				}
+				annex_to = THIS
+			}
+			LHJ = { all_core = { add_core = YEM remove_core = LHJ } }
+			FDL = { all_core = { add_core = YEM remove_core = FDL } }
+			KTH = { all_core = { add_core = YEM remove_core = KTH } }
+			MHR = { all_core = { add_core = YEM remove_core = MHR } }
+			1412 = { remove_core = NYE }
+			any_owned = { limit = { is_core = YEM } secede_province = YEM }
+			create_vassal = YEM
+			diplomatic_influence = { who = YEM value = 400 }
+			relation = { who = YEM value = 400 }
+			YEM = {
+				capital = 1176
+				money = 10000
+				research_points = 6000
+				government = absolute_monarchy
+				1412 = { secede_province = THIS }
+				tech_school = unciv_tech_school
+			}
+			random_owned = {
+				limit = { owner = { primary_culture = british } }
+				YEM = { 
+					government = colonial_company 
+					military_reform = yes_foreign_weapons
+					military_reform = yes_foreign_officers
+					military_reform = yes_foreign_naval_officers
+					military_reform = yes_foreign_artillery
+				}
+			}
+			random_owned = { limit = { exists = NEJ } owner = { diplomatic_influence = { who = NEJ value = 25 } } }
+			random_owned = { limit = { exists = HAL } owner = { diplomatic_influence = { who = HAL value = 25 } } }
+			random_owned = { limit = { exists = BHR } owner = { diplomatic_influence = { who = BHR value = 25 } } }
+			random_owned = { limit = { exists = QAT } owner = { diplomatic_influence = { who = QAT value = 25 } } }
+			random_owned = { limit = { exists = ABU } owner = { diplomatic_influence = { who = ABU value = 25 } } }
+			random_owned = { limit = { exists = KWT } owner = { diplomatic_influence = { who = KWT value = 25 } } }
+		}
+		
+		ai_will_do = { factor = 1 }
+	}
+
+	gold_coast_treaty = {
+		picture = treaty_signing
+		potential = {
+			is_greater_power = yes
+			NOT = { tag = NET }
+			owns = 1908
+			is_canal_enabled = 2
+			OR = {
+				year = 1900
+				ATJ = { exists = no }
+			}
+			NET = {
+				owns = 1909
+				owns = 1413
+				NOT = { owns = 1910 }
+			}
+			NOT = { has_country_flag = gold_coast_treaty }
+		}
+		
+		allow = {
+			war = no
+			money = 10000
+			NET = {
+				war = no
+				owns = 1909
+			}
+		}
+		
+		effect = {
+			set_country_flag = gold_coast_treaty
+			treasury = -10000
+			NET = { country_event = 36960 }
+		}
+		
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				truce_with = NET
+			}
+			modifier = {
+				factor = 0
+				NOT = { relation = { who = NET value = -50 } }
+			}
+		}
+	}
+
+	invest_in_irish = {
+		picture = ireland
+		potential = {
+			tag = ENG
+			NOT = {
+				exists = IRE
+				accepted_culture = irish
+				has_country_flag = invest_in_irish
+			}
+			OR = {
+				government = democracy
+				government = hms_government
+				government = proletarian_dictatorship
+			}
+			OR = {
+				has_country_flag = help_for_the_irish
+				has_country_flag = irish_republican_brotherhood
+			}
+			any_owned_province = { is_core = IRE }
+		}
+		
+		allow = {
+			prestige = 50
+			money = 850001
+			NOT = { citizenship_policy = residency }
+			social_science = 1
+		}
+		
+		effect = {
+			set_country_flag = invest_in_irish
+			random_owned = {
+				limit = { owner = { NOT = { has_country_flag = irish_republican_brotherhood } } }
+				owner = { add_accepted_culture = irish }
+			}
+			prestige = -50
+			treasury = -850000
+			any_owned = {
+				remove_province_modifier = irish_oppression
+				remove_province_modifier = enclosures
+				remove_province_modifier = royal_irish_constabulary
+			}
+			any_pop = {
+				limit = {
+					has_pop_culture = irish
+					has_pop_religion = catholic
+				}
+				militancy = -5
+			}
+		}
+		
+		ai_will_do = {
+			factor = 1
+		}
+	}
+	
+	build_the_big_ben = {
+		picture = bigben
+		potential = {
+			OR = {
+			tag = ENG
+			tag = ENL
+			}
+			year = 1844
+			NOT = { has_country_flag = big_ben_construction }		
+			NOT = { year = 1860 }
+			300 = { NOT = { has_province_modifier = the_big_ben } }
+		}
+		
+		allow = {
+			NOT = { year = 1860 }
+			money = 7500
+			election = no
+			war = no
+			upper_house = {
+				ideology = conservative
+					value = 0.3
+				}
+		}
+		
+		effect = {
+			set_country_flag = big_ben_construction
+			country_event = 3697000
+		}
+	ai_will_do = {
+			factor = 1
+			}
+	}
+
+	rhodesia_renaminc_act = {
+		picture = rhodesia_renaminc_act
+		potential = {
+			tag = RHO
+			owns = 2068
+			owns = 2070
+			owns = 2635
+			NOT = { has_country_flag = renaming_act }
+		}
+		
+		allow = {
+			owns = 2068
+			owns = 2070
+			owns = 2635
+		}
+		
+		effect = {
+			set_country_flag = renaming_act
+			2068 = { state_scope = { change_region_name = "Southern Rhodesia" } }
+		}
+		ai_will_do = { factor = 1 }
+	}
+	
+	durand_line = {
+		picture = mortimer_durand
+		potential = {
+			tag = ENG
+			is_greater_power = yes
+			neighbour = AFG
+			any_owned_province = { is_core = AFG }
+			AFG = { exists = yes }
+			NOT = { has_country_flag = durand_line }
+			NOT = { year = 1920 }
+		}
+		
+		allow = {
+			war = no
+			OR = { 
+				invention = the_dark_continent
+				AND = { 
+					AFG = { vassal_of = THIS }
+					revolution_n_counterrevolution = 1
+				}
+			}
+			NOT = { year = 1920 }
+			#NOT = { relation = { who = AFG value = 100 } }
+		}
+		
+		effect = {
+			set_country_flag = durand_line
+			AFG = { country_event = 3697010 }
+		}
+		ai_will_do = { factor = 1 }
+	}
+	
+	unite_north_yemen_existing = {
+		picture = aden_protectorate
+		potential = {
+			OR = {
+				NOT = { 1178 = { is_core = YEM } }
+				NOT = { 1179 = { is_core = YEM } }
+				NOT = { 1180 = { is_core = YEM } }
+			}			
+			NOT = { tag = NYE }
+			NYE = { exists = yes }
+			OR = {
+				tag = YEM
+				YEM = {
+					exists = yes
+					OR = {
+						vassal_of = THIS
+						in_sphere = THIS
+						}
+					}
+				}
+			}
+		
+		allow = {
+			nationalism_n_imperialism = 1
+			war = no
+			NYE = {
+				war = no
+				OR = {
+					vassal_of = THIS
+					in_sphere = THIS
+				all_core = { 
+					OR = {
+						owned_by = THIS 
+						owner = { in_sphere = THIS }
+						owner = { vassal_of = THIS }
+						}
+					}
+				}
+			}
+			OR = {
+				tag = YEM
+				YEM = {
+					OR = {
+						vassal_of = THIS
+						in_sphere = THIS
+					}
+				}
+			}
+		}
+		
+		effect = {
+			prestige = 5
+			NYE = { all_core = { add_core = YEM } }
+			YEM = { inherit = NYE capital = 1178 }
+		}
+		ai_will_do = { factor = 1 }
+	}
+	
+	unite_yemeni_colonies = {
+		picture = aden_protectorate
+		potential = {
+			has_global_flag = created_aden_protectorate
+			OR = {
+				NOT = { 1178 = { is_core = YEM } }
+				NOT = { 1179 = { is_core = YEM } }
+				NOT = { 1180 = { is_core = YEM } }
+			}
+			OR = {
+				any_owned_province = { is_core = YEM }
+				any_owned_province = { is_core = NYE }
+				NYE = { in_sphere = THIS }
+				NYE = { vassal_of = THIS }
+			}
+			YEM = { exists = no }
+		}
+		
+		allow = {
+			nationalism_n_imperialism = 1
+			war = no
+			YEM = { war = no all_core = { owned_by = THIS } }
+			NYE = {
+				war = no
+				all_core = { 
+					OR = {
+						owned_by = THIS 
+						owner = { in_sphere = THIS }
+						owner = { vassal_of = THIS }
+					}
+				}
+			}
+		}
+		
+		effect = {
+			prestige = 5
+			NYE = { tech_school = unciv_tech_school all_core = { add_core = YEM } }
+			1178 = { secede_province = THIS }
+			1179 = { secede_province = THIS }
+			1180 = { secede_province = THIS }
+			YEM = { tech_school = unciv_tech_school capital = 1178 }
+			
+			random_owned = { limit = { exists = NEJ } owner = { diplomatic_influence = { who = NEJ value = 50 } } }
+			random_owned = { limit = { exists = HAL } owner = { diplomatic_influence = { who = HAL value = 50 } } }
+			random_owned = { limit = { exists = BHR } owner = { diplomatic_influence = { who = BHR value = 50 } } }
+			random_owned = { limit = { exists = QAT } owner = { diplomatic_influence = { who = QAT value = 50 } } }
+			random_owned = { limit = { exists = ABU } owner = { diplomatic_influence = { who = ABU value = 50 } } }
+			random_owned = { limit = { exists = KWT } owner = { diplomatic_influence = { who = KWT value = 50 } } }
+		}
+		
+		ai_will_do = { factor = 1 }
+	}
+
+	anglo_persian_oil_company = { 
+		picture = map_arabia
+		
+		potential = { 
+			tag = ENG
+			year = 1900
+			NOT = {	has_country_flag = apoc	}
+			invention = cracking
+			invention = oil_pumping_machinery
+			PER = { exists = yes }
+		}
+		
+		allow = {
+			money = 150001
+			PER = {
+				OR = {
+					part_of_sphere = no
+					in_sphere = THIS 
+				}
+			}
+		}
+		
+		effect = { 
+			set_country_flag = apoc
+			treasury = -150000
+			prestige = 25
+			PER = { country_event = 110011 }
+		}
+		
+		ai_will_do = { factor = 1 }
+	}
+	
+	
+	johor_protectorate = { 
+		picture = map_east_indies
+		
+		potential = {
+			NOT = { has_country_flag = integrated_johore }
+			OR = {
+				is_sphere_leader_of = JOH
+				any_owned_province = { is_core = JOH }
+			}
+			JOH = {
+				ai = yes
+				exists = yes
+				OR = {
+					vassal_of = THIS
+					is_vassal = no
+				}
+			}
+		}
+		
+		allow = {
+			OR = {
+			AND = {
+				owns = 1384
+				owns = 1387
+				owns = 1386
+				owns = 1390
+				JOH = { part_of_sphere = no }
+				revolution_n_counterrevolution = 1
+			}
+			AND = {
+				is_sphere_leader_of = JOH
+				revolution_n_counterrevolution = 1
+				JOH = { average_militancy = 2 }
+			}
+			AND = {
+				is_sphere_leader_of = JOH
+				nationalism_n_imperialism = 1
+				JOH = { average_militancy = 5 }
+				}
+			}
+		}
+		
+		effect = { 
+			set_country_flag = integrated_johore
+			JOH = { civilized = no tech_school = unciv_tech_school }
+			inherit = JOH
+			any_owned = { limit = { NOT = { OR = { province_id = 1386 province_id = 1384 province_id = 1385 } } } remove_core = JOH }
+			1388 = { remove_core = JOH add_core = PRK }
+			1389 = { remove_core = JOH add_core = PRK }
+			1391 = { remove_core = JOH add_core = PHG }
+			
+			random_owned = { limit = { exists = PRK } owner = { diplomatic_influence = { who = PRK value = 15 } } }
+			random_owned = { limit = { exists = SWK } owner = { diplomatic_influence = { who = SWK value = 15 } } }
+			random_owned = { limit = { exists = BRU } owner = { diplomatic_influence = { who = BRU value = 15 } } }
+			random_owned = { limit = { exists = SIA } owner = { diplomatic_influence = { who = SIA value = 15 } } }
+			random_owned = { limit = { exists = PHG } owner = { diplomatic_influence = { who = PHG value = 15 } } }
+			random_owned = { limit = { exists = SLG } owner = { diplomatic_influence = { who = SLG value = 15 } } }
+		}
+		ai_will_do = { factor = 1 }
+	}
+	
+	pahang_protectorate = { 
+		picture = map_east_indies
+		
+		potential = {
+			is_sphere_leader_of = PHG
+			NOT = { has_country_flag = integrated_pahang }
+			PHG = {
+				ai = yes
+				exists = yes
+				OR = {
+					vassal_of = THIS
+					is_vassal = no
+				}
+			}
+		}
+		
+		allow = {
+			OR = {
+				revolution_n_counterrevolution = 1
+				AND = {
+					nationalism_n_imperialism = 1
+					PHG = { average_militancy = 2 }
+				}
+			}
+		}
+		
+		effect = { 
+			set_country_flag = integrated_pahang
+			PHG = { civilized = no tech_school = unciv_tech_school }
+			PHG = { all_core = { add_province_modifier = { name = nationalist_agitation duration = 730 } } }
+			PHG = { all_core = { remove_core = JOH } }
+			inherit = PHG
+			badboy = 1
+			
+			random_owned = { limit = { exists = JOH } owner = { diplomatic_influence = { who = JOH value = 15 } } }
+			random_owned = { limit = { exists = SWK } owner = { diplomatic_influence = { who = SWK value = 15 } } }
+			random_owned = { limit = { exists = BRU } owner = { diplomatic_influence = { who = BRU value = 15 } } }
+			random_owned = { limit = { exists = SIA } owner = { diplomatic_influence = { who = SIA value = 15 } } }
+			random_owned = { limit = { exists = PRK } owner = { diplomatic_influence = { who = PRK value = 15 } } }
+			random_owned = { limit = { exists = SLG } owner = { diplomatic_influence = { who = SLG value = 15 } } }
+		}
+		ai_will_do = { factor = 1 }
+	}
+	
+	selangor_protectorate = { 
+		picture = map_east_indies
+		
+		potential = {
+			is_sphere_leader_of = SLG
+			NOT = { has_country_flag = integrated_selangor }
+			SLG = {
+				ai = yes
+				exists = yes
+				OR = {
+					vassal_of = THIS
+					is_vassal = no
+				}
+			}
+		}
+		
+		allow = {
+			OR = {
+				revolution_n_counterrevolution = 1
+				AND = {
+					nationalism_n_imperialism = 1
+					SLG = { average_militancy = 2 }
+				}
+			}
+		}
+		
+		effect = {
+			set_country_flag = integrated_selangor
+			SLG = { civilized = no tech_school = unciv_tech_school }
+			inherit = SLG
+			SLG = { all_core = { remove_core = JOH } }
+			badboy = 1
+			
+			random_owned = { limit = { exists = JOH } owner = { diplomatic_influence = { who = JOH value = 15 } } }
+			random_owned = { limit = { exists = SWK } owner = { diplomatic_influence = { who = SWK value = 15 } } }
+			random_owned = { limit = { exists = BRU } owner = { diplomatic_influence = { who = BRU value = 15 } } }
+			random_owned = { limit = { exists = SIA } owner = { diplomatic_influence = { who = SIA value = 15 } } }
+			random_owned = { limit = { exists = PHG } owner = { diplomatic_influence = { who = PHG value = 15 } } }
+			random_owned = { limit = { exists = PRK } owner = { diplomatic_influence = { who = PRK value = 15 } } }
+			}
+			ai_will_do = { factor = 1 }
+		}
+	
+	perak_protectorate = { 
+		picture = map_east_indies
+		
+		potential = {
+			is_sphere_leader_of = PRK
+			NOT = { has_country_flag = integrated_perak }
+			PRK = {
+				ai = yes
+				exists = yes
+				OR = {
+					vassal_of = THIS
+					is_vassal = no
+				}
+			}
+		}
+		
+		allow = {
+			OR = {
+				revolution_n_counterrevolution = 1
+				AND = {
+					nationalism_n_imperialism = 1
+					PRK = { average_militancy = 2 }
+				}
+			}
+		}
+		
+		effect = {
+			set_country_flag = integrated_perak
+			PRK = { civilized = no tech_school = unciv_tech_school }
+			inherit = PRK
+			PRK = { all_core = { remove_core = JOH } }
+			badboy = 1
+			
+			random_owned = { limit = { exists = JOH } owner = { diplomatic_influence = { who = JOH value = 15 } } }
+			random_owned = { limit = { exists = SWK } owner = { diplomatic_influence = { who = SWK value = 15 } } }
+			random_owned = { limit = { exists = BRU } owner = { diplomatic_influence = { who = BRU value = 15 } } }
+			random_owned = { limit = { exists = SIA } owner = { diplomatic_influence = { who = SIA value = 15 } } }
+			random_owned = { limit = { exists = PHG } owner = { diplomatic_influence = { who = PHG value = 15 } } }
+			random_owned = { limit = { exists = SLG } owner = { diplomatic_influence = { who = SLG value = 15 } } }
+		}
+			ai_will_do = { factor = 1 }
+		}
+	
+	tasmania_penal_colony = {
+		picture = drain_the_pinsk_marshes
+		
+		potential = {
+			owns = 2482
+			OR = {
+				2482 = { has_province_modifier = penal_colony }	
+				NOT = { has_global_flag = tasmania_renamed }
+			}
+		}
+		
+		allow = {
+			war = no
+			state_n_government = 1
+			OR = {
+				NOT = { penal_system = colonial_transportation }
+				year = 1853
+			}
+		}
+		
+		effect = {
+			set_global_flag = tasmania_renamed
+			2482 = {
+				change_province_name = "Tasmania"
+				remove_province_modifier = penal_colony
+				add_province_modifier = { name = population_resettlement duration = 60 }
+			}
+		}
+		ai_will_do = { factor = 1 }
+	}
+	
+	cede_aden = {
+		picture = aden_protectorate
+		alert = no
+		
+		potential = {
+			has_global_flag = created_aden_protectorate
+			OR = {
+				owns = 1412
+				1412 = { owner = { OR = { vassal_of = THIS AND = { in_sphere = THIS is_vassal = no ai = yes } } } }
+			}
+			NOT = { tag = YEM }
+			NOT = { tag = NYE }
+			YEM = { exists = yes NOT = { owns = 1412 } }
+			OR = {
+				AND = { tag = LHJ ai = yes is_vassal = no }
+				great_wars_enabled = yes
+			}
+		}
+		
+		
+		allow = {
+			war = no
+			OR = {
+				owns = 1412
+				1412 = {
+					owner = {
+						OR = {
+							vassal_of = THIS
+							AND = { in_sphere = THIS is_vassal = no } 
+						} 
+					}
+				}
+			}
+			1412 = { any_neighbor_province = { owned_by = YEM } }
+			OR = {
+				YEM = { OR = { is_vassal = no vassal_of = THIS } }
+				ai = yes
+			}
+		}
+		
+		effect = {
+			badboy = -2
+			1412 = { remove_core = THIS }
+			
+			random_country = { limit = { owns = 1412 num_of_cities = 2 }
+				1412 = { secede_province = THIS }
+			}
+			
+			random_owned = { limit = { province_id = 1412 }
+				1412 = { secede_province = YEM add_core = YEM remove_core = THIS remove_core = LHJ }
+			}
+			
+			random_country = { limit = { owns = 1412 NOT = { num_of_cities = 2 } }
+				1412 = { add_core = YEM remove_core = THIS remove_core = LHJ }
+				annex_to = YEM
+			}
+			
+			random_owned = { limit = { owner = { is_greater_power = yes } } owner = { diplomatic_influence = { who = YEM value = 100 } } }
+			relation = { who = YEM value = 100 }
+			random_country = { limit = { tag = YEM NOT = { capital = 1178 } } capital = 1412 } 
+		}
+		
+		ai_will_do = {
+			factor = 1
+			modifier = {
+				factor = 0
+				1412 = { any_neighbor_province = { owned_by = THIS } }
+			}
+			
+			modifier = {
+				factor = 0
+				owns = 1412
+			}
+		}
+	}
+
+	christimas_and_cocos_adminstration = {
+		picture = dreams_of_empire
+		
+		potential = {
+			owns = 2244
+			OR = {
+				tag = AST
+				tag = FAS
+				AND = {
+					owns = 2476
+					owns = 2468
+					owns = 2487
+					owns = 2493
+					owns = 2497
+					owns = 2505
+				}
+				AST = { vassal_of = THIS }
+				FAS = { vassal_of = THIS }
+			}
+			OR = { 
+				AND = {
+					OR = { FRA = { has_country_flag = australia_organized } BOR = { has_country_flag = australia_organized } }
+					2244 = { NOT = { is_core = FAS } }
+				}
+				AND = { 
+					OR = { 
+						primary_culture = british
+						primary_culture = australian
+					}
+					2244 = { NOT = { is_core = AST } }
+				}
+			}
+		}
+		
+		allow = {
+			war = no
+			state_n_government = 1
+		}
+		
+		effect = {
+			random_owned = {
+				limit = {
+					owner = {
+						OR = {
+							is_culture_group = british
+							primary_culture = australian
+							primary_culture = anglo_canadian
+						}
+					}
+				}
+				2244 = { add_core = AST }
+				random_country = { limit = { tag = AST exists = yes } 2244 = { secede_province = AST } }
+			}
+			
+			random_owned = {
+				limit = {
+					owner = {
+						OR = {
+							primary_culture = french_australian
+							primary_culture = neo_zelandais
+							is_culture_group = french
+						}
+					}
+				}
+				2244 = { add_core = FAS }
+				random_country = { limit = { tag = FAS exists = yes } 2244 = { secede_province = FAS } }
+			}
+		}
+		
+		ai_will_do = { factor = 1 }
+	}
+	
+	
+	the_foster_act = {
+		picture = william_foster
+		potential = {
+			tag = ENG
+			NOT = { school_reforms = good_schools}
+			NOT = { has_country_flag = foster_act_enacted }
+			year = 1865
+		}		
+		
+		allow = {
+			war = no
+			OR = { 
+				biologism = 1
+				revolution_n_counterrevolution = 1
+			}
+		}
+		
+		effect = {
+			set_country_flag = foster_act_enacted
+			
+			random_owned = {
+				limit = { owner = { school_reforms = acceptable_schools } }
+				owner = { social_reform = good_schools }
+			}
+			
+			random_owned = {
+				limit = { owner = { school_reforms = low_schools } }
+				owner = { social_reform = acceptable_schools }
+			}
+			
+			random_owned = {
+				limit = { owner = { school_reforms = no_schools } }
+				owner = { social_reform = low_schools }
+			}
+		}
+		
+		ai_will_do = { factor = 1 }
+	}
+	
+	
+	londonderry_renaming_act = {
+		picture = londonderry_quay
+		
+		potential = {
+			OR = {
+				AND = {
+					primary_culture = irish
+					NOT = { has_global_flag = londonderry_renamed }
+				}
+				AND = {
+					primary_culture = british
+					has_global_flag = londonderry_renamed
+				}
+			}
+			owns = 255
+		}
+		
+		
+		allow = {
+			war = no
+		}
+		
+		effect = {
+			
+			random_owned = {
+				limit = { owner = { primary_culture = irish } }
+				owner = { set_global_flag = londonderry_renamed 255 = { change_province_name = "Derry" } }
+			}
+			
+			random_owned = {
+				limit = { owner = { primary_culture = british } }
+				owner = { clr_global_flag = londonderry_renamed 255 = { change_province_name = "Londonderry" } }
+			}
+		}
+		
+		ai_will_do = { factor = 1 }
+	}
+}

--- a/Megamp/events/CivilizationAndGunBoats.txt
+++ b/Megamp/events/CivilizationAndGunBoats.txt
@@ -3931,6 +3931,7 @@ country_event = {
     option = {
         name = "EVTOPTA13358"
         prestige = 5
+		badboy = 5
         FROM = {
             tech_school = developing_tech_school
             political_reform = peonage

--- a/Megamp/events/EIC.txt
+++ b/Megamp/events/EIC.txt
@@ -1179,12 +1179,14 @@ country_event = {
             primary_culture = malayalam
             primary_culture = tamil
             primary_culture = telegu
+            primary_culture = asian_minor
+            primary_culture = avadhi
             tag = CRL
         }
     }
 
     mean_time_to_happen = {
-        months = 500
+        months = 250
         modifier = {
             factor = 1.5
             NOT = { average_militancy = 1 }

--- a/Megamp/events/ENGFlavor.txt
+++ b/Megamp/events/ENGFlavor.txt
@@ -1,0 +1,3704 @@
+# Coronation of Queen Victoria
+country_event = {
+	id = 36898
+	title = "EVTNAME36898"
+	desc = "EVTDESC36898"
+	news = yes
+	news_desc_long = "EVTDESC36898_NEWS_LONG"
+	news_desc_medium = "EVTDESC36898_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC36898_NEWS_SHORT"
+	picture = "queenvictoria"
+
+	
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		}
+		year = 1838
+		OR = {
+			government = absolute_monarchy
+			government = prussian_constitutionalism
+			government = hms_government
+		}
+		NOT = { year = 1860 }
+	}
+	
+	major = yes
+	fire_only_once = yes
+	
+	mean_time_to_happen = {
+		months = 5
+		modifier = {
+			factor = 0.1
+			month = 5
+			NOT = { month = 7 }
+		}
+	}
+	
+	option = {
+		name = "EVTOPTA36898"
+		random_owned = { limit = { owner = { is_our_vassal = HAN } } owner = { leave_alliance = HAN release_vassal = HAN diplomatic_influence = { who = HAN value = -200 } } }
+		HAN = { government = absolute_monarchy }
+		random_country = {
+			limit = {
+				tag = AUS
+				is_greater_power = yes
+			}
+			diplomatic_influence = { who = HAN value = 400 }
+		}
+		prestige = 5
+		election = yes
+	}
+}
+
+country_event = {
+
+	id = 36900  
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1836
+		public_meetings = yes_meeting
+		NOT = {
+			year = 1839
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1837
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1838
+		}
+	}
+
+	title = "EVTNAME36900"
+	desc = "EVTDESC36900"
+	picture = "Administration"
+
+	option = {
+		name = "EVTOPTA36900" 
+		any_pop = {
+			consciousness = 1
+		}
+	}
+}
+
+country_event = {
+
+	
+	id = 36901  
+	news = yes
+	news_desc_long = "EVTDESC36901_NEWS_LONG"
+	news_desc_medium = "EVTDESC36901_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC36901_NEWS_SHORT"	
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1837
+		realism = 1 #has this tech
+		NOT = {
+			year = 1840
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1838
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1839
+		}
+	}
+
+	title = "EVTNAME36901"
+	desc = "EVTDESC36901"
+	picture = "Olivertwist"
+
+	option = {
+		name = "EVTOPTA36901" 
+		any_pop = {
+			ideology = {
+				factor = 0.05
+				value = liberal
+			}
+		}
+		craftsmen = {
+			consciousness = 2
+		}
+		labourers = {
+			consciousness = 2
+		}
+		artisans = {
+			consciousness = 2
+		}
+	}
+}
+
+country_event = {
+
+	id = 36902  
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1840
+		NOT = {
+			year = 1843
+			work_hours = no_work_hour_limit 
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1841
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1842
+		}
+	}
+
+	title = "EVTNAME36902"
+	desc = "EVTDESC36902"
+	picture = "Travel"
+
+	option = {
+		name = "EVTOPTA36902" 
+		craftsmen = {
+			consciousness = -1
+		}
+		labourers = {
+			consciousness = -1
+		}
+		artisans = {
+			consciousness = -1
+		}
+	}
+}
+
+country_event = {
+
+	id = 36903  
+	news = yes
+	news_desc_long = "EVTDESC36903_NEWS_LONG"
+	news_desc_medium = "EVTDESC36903_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC36903_NEWS_SHORT"	
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1839
+		OR = {
+			government = absolute_monarchy
+			government = prussian_constitutionalism
+			government = hms_government
+			}
+		NOT = {
+			year = 1842
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1840
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1841
+		}
+	}
+
+	title = "EVTNAME36903"
+	desc = "EVTDESC36903"
+	picture = "VictoriaWedding"
+
+	option = {
+		name = "EVTOPTA36902" 
+		prestige = 5
+	}
+}
+
+country_event = {
+
+	id = 36904  
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1840
+		press_rights = free_press 
+		NOT = {
+			year = 1845
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1841
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1843
+		}
+	}
+
+	title = "EVTNAME36904"
+	desc = "EVTDESC36904"
+	picture = "Punch"
+
+	option = {
+		name = "EVTOPTA36904" 
+		capitalists = {
+			consciousness = 1
+		}
+		clerks = {
+			consciousness = 1
+		}
+		craftsmen = {
+			consciousness = 1
+		}
+		artisans = {
+			consciousness = 1
+		}
+	}
+}
+
+country_event = {
+
+	id = 36905  
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1843
+		public_meetings = yes_meeting
+		NOT = {
+			year = 1849
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1844
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1846
+		}
+	}
+
+	title = "EVTNAME36905"
+	desc = "EVTDESC36905"
+	picture = "ymca"
+
+	option = {
+		name = "EVTOPTA36905" 
+		craftsmen = {
+			consciousness = -1
+		}
+		artisans = {
+			consciousness = -1
+		}
+	}
+}
+
+country_event = {
+
+	id = 36907  
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1846
+		press_rights = free_press 
+		NOT = {
+			year = 1850
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1847
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1848
+		}
+	}
+
+	title = "EVTNAME36907"
+	desc = "EVTDESC36907"
+	picture = "vanityfair"
+
+	option = {
+		name = "EVTOPTA36904" 
+		capitalists = {
+			consciousness = 1
+		}
+		aristocrats = {
+			consciousness = 1
+		}
+		officers = {
+			consciousness = 1
+		}
+		clergymen = {
+			consciousness = 1
+		}
+		clerks = {
+			consciousness = 1
+		}
+	}
+}
+
+country_event = {
+
+	id = 36908  
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1849
+		early_railroad = 1	
+		NOT = {
+			year = 1854
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1850
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1852
+		}
+	}
+
+	title = "EVTNAME36908"
+	desc = "EVTDESC36908"
+	picture = "Expansion"
+
+	option = {
+		name = "EVTOPTA36908" 
+		prestige = 5
+	}
+}
+
+country_event = { 
+	id = 36909
+
+	trigger = {
+		tag = ENG
+		has_global_flag = PlanWorldFair
+		year = 1849
+		NOT = {
+			year = 1852
+			has_country_flag = CrystalPalace
+		}
+		war = no 
+	}
+
+
+	mean_time_to_happen =  {
+		months = 4
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1850
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1851
+		}
+	}
+
+	title = "EVTNAME36909" # World Fair
+	desc = "EVTDESC36909"  
+	picture = "Worldsfair"
+		
+	option = {
+       	name = "EVTOPTA36909"
+		prestige = 50
+		clr_global_flag = PlanWorldFair
+		set_country_flag = CrystalPalace
+	}
+}
+
+country_event = {
+
+	id = 36910  
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1884
+		press_rights = free_press
+		realism = 1 
+		NOT = {
+			year = 1888
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1885
+		}
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1886
+		}
+	}
+
+	title = "EVTNAME36910"
+	desc = "EVTDESC36910"
+	picture = "theatre"
+
+	option = {
+		name = "EVTOPTA36910" 
+		prestige = 5
+	}
+}
+
+country_event = {
+
+	id = 36911  
+	news = yes
+	news_desc_long = "EVTDESC36911_NEWS_LONG"
+	news_desc_medium = "EVTDESC36911_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC36911_NEWS_SHORT"
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1892
+		press_rights = free_press
+		realism = 1 
+		nationalism_n_imperialism = 1
+		NOT = {
+			exists = IRE
+			year = 1896
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1893
+		}
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1894
+		}
+	}
+
+	title = "EVTNAME36911"
+	desc = "EVTDESC36911"
+	picture = "Yeats"
+
+	option = {
+		name = "EVTOPTA36911" 
+		prestige = 5
+	}
+}
+
+country_event = {
+
+	id = 36912  
+	news = yes
+	news_desc_long = "EVTDESC36912_NEWS_LONG"
+	news_desc_medium = "EVTDESC36912_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC36912_NEWS_SHORT"
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1917
+		press_rights = free_press
+		expressionism = 1 
+		NOT = {
+			year = 1925
+		}
+	}
+	
+	fire_only_once = yes
+	
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1918
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1921
+		}
+	}
+
+	title = "EVTNAME36912"
+	desc = "EVTDESC36912"
+	picture = "Hopkins"
+	
+
+	option = {
+		name = "EVTOPTA36912" 
+		prestige = 5
+	}
+}
+
+country_event = {
+
+	id = 36913 
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1850
+		exists = USA
+		NOT = {
+			year = 1855
+			war_with = USA
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1851
+		}
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1853
+		}
+	}
+
+	title = "EVTNAME36913"
+	desc = "EVTDESC36913"
+	picture = "americascup"
+
+	option = {
+		name = "EVTOPTA36913" 
+		prestige = 5
+	}
+}
+
+country_event = {
+
+	id = 36914 
+	title = "EVTNAME36914"
+	desc = "EVTDESC36914"
+	picture = "ssgreatbritan"
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1842
+		invention = steamer_transports
+		NOT = { year = 1860 }
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1843
+		}
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1845
+		}
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1860
+		}
+	}
+
+	option = {
+		name = "EVTOPTA36914" 
+		prestige = 5
+	}
+}
+
+country_event = {
+
+	id = 36915 
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1896
+		OR = {
+			government = absolute_monarchy
+			government = prussian_constitutionalism
+			government = hms_government
+		}
+		NOT = {
+			year = 1900
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1897
+		}
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1898
+		}
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1899
+		}
+	}
+
+	title = "EVTNAME36915"
+	desc = "EVTDESC36915"
+	picture = "queenvictoria"
+
+	option = {
+		name = "EVTOPTA36915" 
+		prestige = 5
+	}
+}
+
+country_event = {
+
+	id = 36917  
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1856
+		public_meetings = yes_meeting #allows public meetings
+		NOT = {
+			year = 1859
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1857
+		}
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1858
+		}
+	}
+
+	title = "EVTNAME36917"
+	desc = "EVTDESC36917"
+	picture = "anticorn"
+
+	option = {
+		name = "EVTOPTA36917" 
+		prestige = 1
+	}
+}
+
+country_event = {
+
+	id = 36918  
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1856
+		public_meetings = yes_meeting #allows public meetings
+		NOT = {
+			year = 1859
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1857
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1858
+		}
+	}
+
+	title = "EVTNAME36918"
+	desc = "EVTDESC36918"
+	picture = "FC_Sheffield"
+
+	option = {
+		name = "EVTOPTA36918" 
+		prestige = 1
+		farmers = {
+			consciousness = -1
+		}
+		labourers = {
+			consciousness = -1
+		}
+		artisans = {
+			consciousness = -1
+		}
+		craftsmen = {
+			consciousness = -1
+		}
+	}
+}
+
+country_event = {
+
+	id = 36919  
+	news = yes
+	news_desc_long = "EVTDESC36919_NEWS_LONG"
+	news_desc_medium = "EVTDESC36919_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC36919_NEWS_SHORT"
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		}
+		war = yes
+		medicine = 1 
+		year = 1851
+		NOT = {
+			year = 1858
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1853
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1855
+		}
+	}
+
+	title = "EVTNAME36919"
+	desc = "EVTDESC36919"
+	picture = "Nightingale"
+
+	option = {
+		name = "EVTOPTA36919" 
+		war_exhaustion = -1
+	}
+}
+
+country_event = {
+
+	id = 36921
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1901
+		ruling_party_ideology = conservative
+		NOT = {
+			year = 1906
+		}
+	}
+ 
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1902
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1903
+		}
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1905
+		}
+	}
+
+	title = "EVTNAME36921"
+	desc = "EVTDESC36921"
+	picture = "Strike"
+
+	option = {
+		name = "EVTOPTA36921" 
+		labourers = {
+			ideology = {
+				value = socialist
+				factor = 0.1
+			}
+			consciousness = 1
+		}
+		craftsmen = {
+			ideology = {
+				value = socialist
+				factor = 0.1
+			}
+			consciousness = 1
+		}
+	}
+}
+
+country_event = {
+
+	id = 36922
+	news = yes
+	news_desc_long = "EVTDESC36922_NEWS_LONG"
+	news_desc_medium = "EVTDESC36922_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC36922_NEWS_SHORT"
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1881
+		owns = 2468 #Sydney
+		owns = 2476 #Melbourne
+		owns = 2491 #Adelaide
+		NOT = {
+			exists = AST
+			year = 1886
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1882
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1883
+		}
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1884
+		}
+	}
+
+	title = "EVTNAME36922"
+	desc = "EVTDESC36922"
+	picture = "ashes"
+
+	option = {
+		name = "EVTOPTA36922" 
+		prestige = -3
+	}
+}
+
+country_event = {
+
+	id = 36923
+	news = yes
+	news_desc_long = "EVTDESC36923_NEWS_LONG"
+	news_desc_medium = "EVTDESC36923_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC36923_NEWS_SHORT"
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		functionalism = 1
+		year = 1858
+		NOT = {
+			year = 1862
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1859
+		}
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1860
+		}
+	}
+
+	title = "EVTNAME36923"
+	desc = "EVTDESC36923"
+	picture = "darwin"
+
+	option = {
+		name = "EVTOPTA36923" 
+		prestige = 25
+		clergymen = {
+			dominant_issue = {
+				value = secularized
+				factor = 0.25
+			}
+			dominant_issue = {
+				value = pro_atheism
+				factor = 0.1
+			}
+			consciousness = 2
+		}
+		set_country_flag = Darwin
+	}
+}
+
+country_event = {
+
+	id = 36924  
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1876
+		public_meetings = yes_meeting #allows public meetings
+		NOT = {
+			year = 1880
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1877
+		}
+		
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1878
+		}
+	}
+
+	title = "EVTNAME36924"
+	desc = "EVTDESC36924"
+	picture = "wimbledon"
+
+	option = {
+		name = "EVTOPTA36924" 
+		prestige = 5
+	}
+}
+ 
+country_event = {
+
+	id = 36925  
+	news = yes
+	news_desc_long = "EVTDESC36925_NEWS_LONG"
+	news_desc_medium = "EVTDESC36925_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC36925_NEWS_SHORT"
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		}
+		year = 1887
+		experimental_psychology = 1
+		NOT = {
+			year = 1890
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1888
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1889
+		}
+	}
+
+	title = "EVTNAME36925"
+	desc = "EVTDESC36925"
+	picture = "jacktheripper"
+
+	option = {
+		name = "EVTOPTA36925" 
+		prestige = -5
+		any_pop = {
+			consciousness = 1
+		}
+		set_country_flag = JackTheRipper
+	}
+
+	option = {
+		name = "EVTOPTB36925" 
+		prestige = -5
+		any_pop = {
+			militancy = 1
+		}
+		set_country_flag = JackTheRipper
+	}
+}
+
+country_event = {
+
+	id = 36926  
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1853
+		public_meetings = yes_meeting
+		NOT = {
+			year = 1856
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1854
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1855
+		}
+	}
+
+	title = "EVTNAME36926"
+	desc = "EVTDESC36926"
+	picture = "midsummer"
+
+	option = {
+		name = "EVTOPTA36926" 
+		prestige = 5
+	}
+}
+
+country_event = {
+
+	id = 36927 
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1864
+		NOT = {
+			year = 1867
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1865
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1866
+		}
+	}
+
+	title = "EVTNAME36927"
+	desc = "EVTDESC36927"
+	picture = "Alice"
+
+	option = {
+		name = "EVTOPTA36927" 
+		prestige = 5
+	}
+}
+
+country_event = {
+
+	id = 36928 
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1867
+		NOT = {
+			year = 1870
+		}
+	}
+
+	fire_only_once = yes
+	
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1868
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1869
+		}
+	}
+
+	title = "EVTNAME36928"
+	desc = "EVTDESC36928"
+	picture = "Thermopylae"
+
+	option = {
+		name = "EVTOPTA36928" 
+		prestige = 2
+	}
+}
+
+country_event = {
+
+	id = 36929 
+	news = yes
+	news_desc_long = "EVTDESC36929_NEWS_LONG"
+	news_desc_medium = "EVTDESC36929_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC36929_NEWS_SHORT"
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		}
+		year = 1879
+		owns = 270
+		owns = 269
+		NOT = {
+			exists = SCO
+			year = 1882
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1880
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1881
+		}
+	}
+
+	title = "EVTNAME36929"
+	desc = "EVTDESC36929"
+	picture = "TayBridge"
+
+	option = {
+		name = "EVTOPTA36929" 
+		prestige = -10
+	}
+}
+
+country_event = {
+
+	id = 36930
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1865
+		NOT = {
+			OR = {
+			war_with = CHI
+			war_with = QNG
+			}
+			year = 1868
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1866
+		}
+		
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1867
+		}
+	}
+
+	title = "EVTNAME36930"
+	desc = "EVTDESC36930"
+	picture = "tearace"
+
+	option = {
+		name = "EVTOPTA36930" 
+		prestige = 3
+	}
+}
+
+country_event = {
+
+	id = 36932
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1897
+		expressionism = 1
+		NOT = {
+			year = 1905
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1898
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1900
+		}
+	}
+
+	title = "EVTNAME36932"
+	desc = "EVTDESC36932"
+	picture = "WMorris"
+
+	option = {
+		name = "EVTOPTA36932" 
+		prestige = 3
+	}
+}
+
+country_event = {
+
+	id = 36933
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		}
+		year = 1867
+		NOT = {
+			year = 1870
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 6
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1868
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1869
+		}
+	}
+
+	title = "EVTNAME36933"
+	desc = "EVTDESC36933"
+	picture = "AthleticChamp"
+
+	option = {
+		name = "EVTOPTA36933" 
+		any_pop = {
+			consciousness = 1
+		}
+	}
+}
+
+country_event = {
+
+	id = 36935 #parallel to AST43800, ENG more often than not will own AST directly at this point, so needs own event.
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		} 
+		year = 1844
+		owns = 2468 #Sydney
+		owns = 2476 #Melbourne
+		owns = 2491 #Adelaide
+		NOT = {
+			year = 1849
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 10
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1845
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1846
+		}
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1847
+		}
+	}
+
+	title = "EVTNAME43800"
+	desc = "EVTDESC43800"
+	picture = "redline"
+
+	option = {
+		name = "EVTOPTA43800" 
+		prestige = 5
+	}
+}
+
+country_event = {
+
+	id = 36936 #parallel to AST43801, ENG more often than not will own AST directly at this point, so needs own event.
+
+	trigger = {
+		tag = AST  
+		year = 1859
+		owns = 2468 #Sydney
+		owns = 2476 #Melbourne
+		owns = 2491 #Adelaide
+		NOT = {
+			year = 1864
+		}
+	}
+	
+	fire_only_once = yes
+	allow_multiple_instances = no
+ 
+	mean_time_to_happen =  {
+		months = 10
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1860
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1861
+		}
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1862
+		}
+	}
+
+	title = "EVTNAME43801"
+	desc = "EVTDESC43801"
+	picture = "BurkeandWills"
+
+	option = {
+		name = "EVTOPTA43801" 
+		prestige = 5
+	}
+}
+
+
+country_event = {
+
+	id = 36937 #sets up COB35000
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		}
+		year = 1836
+		exists = COB
+		OR = {
+			war_with = GCF
+			war_with = GER
+			war_with = PRU
+			}
+		OR = {
+			government = absolute_monarchy
+			government = prussian_constitutionalism
+			government = hms_government
+			}
+		NOT = {
+			year = 1936
+			has_global_flag = ENGRoyalHouseAnglified
+			}
+		}
+ 
+	mean_time_to_happen =  {
+		months = 12
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1860
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1880
+		}
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1900
+		}
+	}
+
+	title = "EVTNAME36937"
+	desc = "EVTDESC36937"
+	picture = "windsor"
+
+	option = {
+		name = "EVTOPTA36937" 
+		set_global_flag = ENGRoyalHouseAnglified
+		any_pop = {
+			consciousness = 1
+		}
+	}
+}
+
+province_event = {
+
+	id = 36938
+
+	trigger = {
+		province_id = 1251 #Calcutta
+		year = 1864
+		NOT = {
+			year = 1867
+			}
+		
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 5
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1865
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1866
+		}
+	}
+
+	title = "EVTNAME36938"
+	desc = "EVTDESC36938"
+	picture = "BengaliNovel"
+
+	option = {
+		name = "EVTOPTA36938" 
+		any_pop = {
+			limit = {
+				has_pop_religion = hindu 
+			}
+			militancy = 3
+			consciousness = 2
+		}
+
+	}
+
+}
+
+country_event = {
+
+	id = 36939
+	news = yes
+	news_desc_long = "EVTDESC36939_NEWS_LONG"
+	news_desc_medium = "EVTDESC36939_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC36939_NEWS_SHORT"
+
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+			tag = EIC
+		}
+		owns = 1251 #Calcutta
+		year = 1853
+		NOT = { year = 1857 }
+		MUG = { 
+			OR = {
+				exists = no
+			AND = {
+				exists = yes
+				vassal_of = THIS
+				}
+			}
+		}
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 5
+
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1855
+		}
+
+
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1856
+		}
+	}
+
+	title = "EVTNAME36939"
+	desc = "EVTDESC36939"
+	picture = "LordDalhousie"
+
+	option = {
+		name = "EVTOPTA36939"
+		any_pop = {
+			limit = {
+				has_pop_religion = hindu
+			}
+			militancy = 3
+		}
+		any_pop = {
+			limit = {
+				has_pop_religion = sunni
+			}
+			militancy = 2
+		}
+	}
+
+	option = {
+		name = "EVTOPTB36939" 
+		officers = {
+			consciousness = 1
+			}
+		capitalists = {
+			consciousness = 1
+			}
+		any_pop = {
+			limit = {
+				has_pop_religion = hindu
+			}
+			militancy = -1
+		}
+		any_pop = {
+			limit = {
+				has_pop_religion = sunni
+			}
+			militancy = -1
+		}	
+	}
+
+}
+
+#Treaty of Waitangi
+country_event = {
+
+	id = 36940
+	title = "EVTNAME36940"
+	desc = "EVTDESC36940"
+	news = yes
+	news_desc_long = "EVTDESC36940_NEWS_LONG"
+	news_desc_medium = "EVTDESC36940_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC36940_NEWS_SHORT"
+	picture = "Waitangi"
+
+	trigger = {
+		NOT = { has_global_flag = treaty_of_waitangi }
+		owns = 2509 #Auckland
+		year = 1840
+	}
+
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 5
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1842
+		}
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1845
+		}
+	}
+
+	option = {
+		name = "EVTOPTA36940"
+		set_global_flag = treaty_of_waitangi
+		prestige = 5
+		ENG_2509 = { add_core = THIS add_core = NZL } #North Island
+		ENG_2513 = { add_core = THIS add_core = NZL } #South Island
+		any_pop = { 
+			limit = { has_pop_culture = maori }
+			militancy = -3
+		}
+		any_owned = {
+			limit = {
+				is_core = NZL
+				is_colonial = yes
+			}
+			add_province_modifier = {
+				name = small_immigration_boom
+				duration = 1825
+			}
+		}
+	}
+}
+
+#The Flagstaff War
+country_event = {
+
+	id = 36941
+	title = "EVTNAME36941"
+	desc = "EVTDESC36941"
+
+	news = yes
+	news_desc_long = "EVTDESC36941_NEWS_LONG"
+	news_desc_medium = "EVTDESC36941_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC36941_NEWS_SHORT"
+	picture = "flagstaffwar"
+
+	trigger = {
+		owns = 2509 #Auckland
+		has_global_flag = treaty_of_waitangi
+		year = 1845
+	}
+
+	fire_only_once = yes
+ 
+	mean_time_to_happen =  {
+		months = 5
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1847
+		}
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1849
+		}
+	}
+
+	option = {
+		name = "EVTOPTA36941"
+		set_country_flag = flagstaff_war
+		ENG_2509 = { add_core = AOT }
+		ENG_2513 = { add_core = AOT }
+		any_owned = {
+			limit = {
+				OR = {
+					region = ENG_2509
+					region = ENG_2513
+				}
+				culture = maori
+			}
+			add_province_modifier = {
+				name = peasant_revolt
+				duration = 365
+			}
+		}
+		any_pop = { 
+			limit = { has_pop_culture = maori }
+			militancy = 5
+		}
+	}
+}
+#The Fencibles
+country_event = {
+	
+	id = 36942
+	title = "EVTNAME36942"
+	desc = "EVTDESC36942"
+	picture = "emigration"
+
+	fire_only_once = yes
+
+	trigger = {
+		is_greater_power = yes
+		2509 = {
+			owned_by = THIS
+			is_colonial = yes 
+		}
+		war = no
+		owns = 2510
+		owns = 2511
+		owns = 2512
+		NZL = { exists = no }
+		NZF = { exists = no }
+	}
+
+	mean_time_to_happen = {
+		months = 5
+		modifier = {
+			factor = 0.75 #increase likelihood to happen
+			year = 1847
+		}
+		modifier = {
+			factor = 0.95 #increase likelihood to happen
+			year = 1849
+		}
+	}
+
+	option = {
+		name = "EVTOPTA36942"
+		ENG_2509 = {
+			add_province_modifier = {
+				name =	colonial_recruitment
+				duration = 730
+			}
+		}
+	}
+}
+
+#The Danish Gold Coast
+country_event = {
+	id = 36950
+	title = "EVTNAME36950"
+	desc = "EVTDESC36950"
+	picture = "administration"
+	
+	is_triggered_only = yes
+
+	option = {
+		name = "EVT36950OPTA"
+		treasury = -35000
+		DEN = {
+			prestige = 5 
+			treasury = 35000
+		}
+		diplomatic_influence = { who = ASH value = -200 }
+		relation = { who = ASH value = -200 }
+		1907 = { secede_province = THIS remove_core = FROM }
+		ai_chance = {
+			factor = 100
+		}
+	}
+	option = {
+		name = "EVT36950OPTB"
+		prestige = -5
+		ai_chance = {
+			factor = 0
+		}
+	}
+}
+
+country_event = {
+	id = 36955
+	title = "EVTNAME36955" #Conflict with Burma
+	desc = "EVTDESC36955"
+	news = yes
+	news_title = "EVTNAME36955_NEWS_TITLE"
+	news_desc_long = "EVTDESC36955_NEWS_LONG"
+	news_desc_medium = "EVTDESC36955_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC36955_NEWS_SHORT"
+	picture = "Opiumwar"
+	
+	trigger = {
+		tag = ENG
+		is_greater_power = yes
+		nationalism_n_imperialism = 1
+		NOT = { has_global_flag = berlin_conference }
+		BUR = {
+			war = no
+			civilized = no
+			is_vassal = no
+			exists = yes
+			OR = {
+				neighbour = ENG
+				neighbour = EIC
+			}
+			number_of_states = 2
+			any_owned_province = { port = yes }
+			NOT = { truce_with = ENG }
+			owns = 1332
+		}
+		OR = {
+			war_policy = jingoism
+			war_policy = pro_military
+		}
+	}
+	
+	mean_time_to_happen = {
+		months = 12
+		
+		modifier = {
+			factor = 0.75
+			year = 1852
+		}
+		
+		modifier = {
+			factor = 0.5
+			year = 1853
+		}
+	}
+	
+	option = {
+		name = "EVT36955OPTA"
+		prestige = 5
+		badboy = 2
+		relation = { who = BUR value = -200 }
+		diplomatic_influence = { who = BUR value = -200 }
+		casus_belli = {
+			target = BUR
+			type = demand_concession_NI_casus_belli
+			months = 60
+		}
+		war = {
+			target = BUR
+			attacker_goal = { 
+				casus_belli = demand_concession_NI_casus_belli 
+				state_province_id = 1332
+			}
+			defender_goal = { casus_belli = status_quo }
+		}
+		ai_chance = {
+			factor = 99
+		}
+	}
+	
+	option = {
+		name = "EVT36955OPTB"
+		prestige = -25
+		relation = { who = BUR value = 25 }
+		any_pop = {
+			limit = { is_primary_culture = yes }
+			dominant_issue = {
+				factor = 0.05
+				value = pacifism
+			}
+		}
+		any_pop = {
+			limit = {
+				location = { is_core = HND }
+				is_primary_culture = no
+			}
+			militancy = 2
+		}
+		ai_chance = {
+			factor = 1
+		}
+	}
+}
+
+country_event = {
+	id = 36960
+	title = "EVTNAME36960" #The Gold Coast Treaty
+	desc = "EVTDESC36960"
+	picture = "deliberation"
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = "EVT36960OPTA"
+		treasury = 10000
+		relation = { who = FROM value = 100 }
+		FROM = { country_event = 36961 }
+		ai_chance = {
+			factor = 75
+			modifier = {
+				factor = 0.5
+				NOT = { relation = { who = FROM value = -50 } }
+			}
+		}
+	}
+	
+	option = {
+		name = "EVT36960OPTB"
+		relation = { who = FROM value = -50 }
+		FROM = { country_event = 36962 }
+		ai_chance = {
+			factor = 25
+			modifier = {
+				factor = 2
+				NOT = { relation = { who = FROM value = -50 } }
+			}
+			modifier = {
+				factor = 2
+				part_of_sphere = yes
+				NOT = { in_sphere = FROM }
+			}
+			modifier = {
+				factor = 0.5
+				relation = { who = FROM value = 150 }
+			}
+			modifier = {
+				factor = 0.5
+				alliance_with = FROM
+			}
+			modifier = {
+				factor = 0
+				in_sphere = FROM
+			}
+			modifier = {
+				factor = 0
+				vassal_of = FROM
+			}
+		}
+	}
+}
+
+country_event = {
+	id = 36961
+	title = "EVTNAME36961"
+	desc = "EVTDESC36961"
+	news = yes
+	news_title = "EVTNAME36961_NEWS_TITLE"
+	news_desc_long = "EVTDESC36961_NEWS_LONG"
+	news_desc_medium = "EVTDESC36961_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC36961_NEWS_SHORT"
+	picture = "treaty"
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = "EVT36961OPTA"
+		random_country = {
+			limit = {
+				tag = FROM
+				is_greater_power = no
+			}
+			THIS = { diplomatic_influence = { who = FROM value = 100 } }
+		}
+		relation = { who = FROM value = 50 }
+		random_country = {
+			limit = { tag = FROM }
+			random_owned = { limit = { province_id = 1909 } 1909 = { secede_province = THIS } }
+			random_owned = { limit = { province_id = 1907 } 1907 = { secede_province = THIS } }
+			random_owned = { limit = { province_id = 1908 } 1908 = { secede_province = THIS } }
+		}
+		1909 = { secede_province = THIS }
+		random_country = {
+			limit = {
+				tag = ATJ
+				exists = yes
+			}
+			leave_alliance = THIS
+			THIS = { diplomatic_influence = { who = ATJ value = -200 } }
+		}
+		random_country = {
+			limit = {
+				tag = SAK
+				exists = yes
+			}
+			leave_alliance = THIS
+			THIS = { diplomatic_influence = { who = SAK value = -200 } }
+		}
+		random_country = {
+			limit = {
+				tag = SLW
+				exists = yes
+			}
+			leave_alliance = THIS
+			THIS = { diplomatic_influence = { who = SLW value = -200 } }
+		}
+		random_country = {
+			limit = {
+				tag = BAL
+				exists = yes
+			}
+			leave_alliance = THIS
+			THIS = { diplomatic_influence = { who = BAL value = -200 } }
+		}
+		random_country = {
+			limit = {
+				tag = KTI
+				exists = yes
+			}
+			leave_alliance = THIS
+			THIS = { diplomatic_influence = { who = KTI value = -200 } }
+		}
+		random_country = {
+			limit = {
+				tag = LAN
+				exists = yes
+			}
+			leave_alliance = THIS
+			THIS = { diplomatic_influence = { who = LAN value = -200 } }
+		}
+		random_country = {
+			limit = {
+				tag = KLM
+				exists = yes
+			}
+			leave_alliance = THIS
+			THIS = { diplomatic_influence = { who = KLM value = -200 } }
+		}
+	}
+}
+
+country_event = {
+	id = 36962
+	title = "EVTNAME36962"
+	desc = "EVTDESC36962"
+	picture = "treaty"
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = "EVT36962OPTA"
+		prestige = -10
+		treasury = 10000
+	}
+	
+	option = {
+		name = "EVT36962OPTB"
+		set_country_flag = claimed_sekondi
+		add_country_modifier = { name = foreign_claims duration = 1825 }
+		badboy = 2
+		treasury = 10000
+		diplomatic_influence = { who = FROM value = -100 }
+		relation = { who = FROM value = -50 }
+		leave_alliance = FROM
+		1909 = { add_core = THIS }
+		casus_belli = {
+			target = FROM
+			type = humiliate
+			months = 12
+		}
+	}
+}
+
+province_event = {
+	id = 36963
+	title = "EVTNAME36963"
+	desc = "EVTDESC36963"
+	
+	trigger = {
+		province_id = 1909
+		owner = {
+			OR = {
+				any_neighbor_country = { has_country_flag = claimed_sekondi NOT = { has_country_modifier = foreign_claims } }
+				any_greater_power = { has_country_flag = claimed_sekondi NOT = { has_country_modifier = foreign_claims } }
+			}
+		}
+	}
+	
+	mean_time_to_happen = { days = 1 }
+	fire_only_once = yes
+	
+	option = {
+		name = "EVT36963OPTA"
+		random_country = {
+			limit = { has_country_flag = claimed_sekondi NOT = { has_country_modifier = foreign_claims } }
+			country_event = 36964
+		}
+	}
+}
+
+country_event = {
+	id = 36964
+	title = "EVTNAME36964"
+	desc = "EVTDESC36964"
+	picture = "treaty"
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = "EVT36964OPTA"
+		1909 = { remove_core = THIS }
+		clr_country_flag = claimed_sekondi 
+	}
+}
+
+country_event = {
+	id = 36965
+	title = "EVTNAME36965" #The Lagos Slave Trade
+	desc = "EVTDESC36965"
+	picture = "slaves"
+	
+	trigger = {
+		tag = ENG
+		war = no
+		slavery = no_slavery
+		is_greater_power = yes
+		nationalism_n_imperialism = 1
+		year = 1860
+		NOT = { has_country_flag = lagos_slave_trade }
+		1923 = {
+			owner = {
+				war = no
+				civilized = no
+				slavery = yes_slavery
+				ai = yes
+				OR = {
+					part_of_sphere = no
+					in_sphere = ENG
+				}
+			}
+		}
+	}
+	
+	mean_time_to_happen = {
+		months = 6
+	}
+	
+	option = {
+		name = "EVT36965OPTA"
+		set_country_flag = lagos_slave_trade
+		1923 = { owner = { country_event = 36966 } }
+		1923 = { secede_province = THIS }
+		relation = { who = SOK value = -400 }
+		relation = { who = OYO value = -400 }
+		relation = { who = ARO value = -400 }
+		relation = { who = WRI value = -400 }
+		relation = { who = BEN value = -400 }
+		relation = { who = CLA value = -400 }
+		ai_chance = { factor = 100 }
+	}
+	
+	option = {
+		name = "EVT36965OPTB"
+		set_country_flag = lagos_slave_trade
+		prestige = -10
+		badboy = -2
+		ai_chance = { factor = 0 }
+	}
+}
+
+country_event = {
+	id = 36966
+	title = "EVTNAME36966" #United Kingdom Seizes Lagos!
+	desc = "EVTDESC36966"
+	news = yes
+	news_desc_long = "EVTDESC36966_NEWS_LONG"
+	news_desc_medium = "EVTDESC36966_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC36966_NEWS_SHORT"
+	picture = "uk_seizes_lagos"
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = "EVT36966OPTA"
+		prestige = -10
+		relation = { who = FROM value = -400 }
+		any_pop = { militancy = 3 }
+		ai_chance = {
+			factor = 90
+			modifier = {
+				factor = 0.1
+				part_of_sphere = yes
+				NOT = { in_sphere = FROM }
+			}
+		}
+	}
+	
+	option = {
+		name = "EVT36966OPTB"
+		prestige = 10
+		any_pop = { militancy = -6 }
+		relation = { who = FROM value = -100 }
+		leave_alliance = FROM
+		FROM = {
+			diplomatic_influence = { who = THIS value = -200 }
+		}
+		war = {
+			target = FROM
+			attacker_goal = {
+				casus_belli = acquire_any_state
+				state_province_id = 1923
+			}
+			call_ally = yes
+		}
+		ai_chance = {
+			factor = 10
+			modifier = {
+				factor = 0.5
+				FROM = { brigades_compare = 5 }
+			}
+			modifier = {
+				factor = 0
+				in_sphere = FROM
+			}
+		}
+	}
+}
+
+
+country_event = {
+	id = 36967
+	title = "EVTNAME36967" #United Kingdom Seizes Aden!
+	desc = "EVTDESC36967"
+	picture = "uk_seizes_aden"
+	
+	fire_only_once = yes
+	
+	trigger = {
+		tag = ENG
+		war = no
+		NOT = { owns = 1412 }
+		year = 1839
+		LHJ = { exists = yes ai = yes }
+	}
+			
+	mean_time_to_happen = { months = 1 }
+	
+	option = {
+		name = "EVT36967OPTA"
+		badboy = 1
+		relation = { who = LHJ value = -400 }
+		diplomatic_influence = { who = LHJ value = -400 }
+		 casus_belli ={
+			target = LHJ
+			type = establish_protectorate_casus_belli
+			months = 50	
+		}
+		ai_chance = {
+			factor = 0.01
+			modifier = { factor = 100 war = yes }
+		}
+	}
+		
+	option = {
+		name = "EVT36967OPTB"
+		badboy = 1
+		relation = { who = LHJ value = -400 }
+		diplomatic_influence = { who = LHJ value = -400 }
+		casus_belli = { target = LHJ type = conquest_any months = 36 }
+		 war = {
+			target = LHJ
+			attacker_goal = { casus_belli = conquest_any }
+			defender_goal = { casus_belli = humiliate }
+			call_ally = no
+		}
+		random_country = { limit = { neighbour = LHJ NOT = { alliance_with = LHJ } } ENG = { military_access = THIS } }
+		ai_chance = {
+			factor = 0.99
+			modifier = { factor = 0 war = yes }
+		}
+	}
+}
+	
+country_event = {
+	id = 3697000
+	title = "EVTNAME3697000" #Start building the big ben
+	desc = "EVTDESC3697000"
+	picture = "big_ben_construction"
+	
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = "EVT37236OPTA"
+		random_owned = { limit = { owner = { ai = no } } owner = { treasury = -40000 } }
+		random_owned = {
+			limit = { owner = { ai = yes NOT = { check_variable = { which = owed_cash_money value = 1 } } } }
+			owner = { set_variable = { which = owed_cash_money value = 40 } }
+		}
+		random_owned = {
+			limit = { owner = { ai = yes check_variable = { which = owed_cash_money value = 9 } } }
+			owner = { change_variable = { which = owed_cash_money value = 40 } }
+		}
+		random_list = {
+			50 = { add_country_modifier = { name =  bigben_construction duration = 2920 } }
+			40 = { add_country_modifier = { name = bigben_construction duration = 3650 } }
+			10 = { add_country_modifier = { name = bigben_construction duration = 4380 } }
+		}
+		
+		ai_chance = {
+			factor = 40
+		}
+	}
+	
+	option = {
+		name = "EVT37236OPTB"
+		random_owned = { limit = { owner = { ai = no } } owner = { treasury = -30000 } }
+		random_owned = {
+			limit = { owner = { ai = yes NOT = { check_variable = { which = owed_cash_money value = 1 } } } }
+			owner = { set_variable = { which = owed_cash_money value = 30 } }
+		}
+		random_owned = {
+			limit = { owner = { ai = yes check_variable = { which = owed_cash_money value = 9 } } }
+			owner = { change_variable = { which = owed_cash_money value = 30 } }
+		}
+		random_list = {
+			30 = { add_country_modifier = { name = bigben_construction duration = 2920 } }
+			50 = { add_country_modifier = { name = bigben_construction duration = 3650 } }
+			20 = { add_country_modifier = { name = bigben_construction duration = 4380 } }
+		}
+		
+		ai_chance = {
+			factor = 40
+		}
+	}
+	
+	option = {
+		name = "EVT37236OPTC"
+		random_owned = { limit = { owner = { ai = no } } owner = { treasury = -20000 } }
+		random_owned = {
+			limit = { owner = { ai = yes NOT = { check_variable = { which = owed_cash_money value = 1 } } } }
+			owner = { set_variable = { which = owed_cash_money value = 20 } }
+		}
+		random_owned = {
+			limit = { owner = { ai = yes check_variable = { which = owed_cash_money value = 9 } } }
+			owner = { change_variable = { which = owed_cash_money value = 20 } }
+		}
+		random_list = {
+			30 = { add_country_modifier = { name = bigben_construction duration = 2920 } }
+			30 = { add_country_modifier = { name = bigben_construction duration = 3650 } }
+			40 = { add_country_modifier = { name = bigben_construction duration = 4380 } }
+		}
+		
+		ai_chance = {
+			factor = 20
+		}
+	}
+}
+
+country_event = {
+
+	id = 3697001
+	title = "EVTNAME3697001" #Big Ben Finished
+	desc = "EVTDESC3697001"
+	picture = "big_ben_finished"
+
+	fire_only_once = yes
+	
+	trigger = {
+	OR = {
+		tag = ENG
+		tag = ENL
+		}
+		NOT = { has_country_modifier = bigben_construction }
+		has_country_flag = big_ben_construction	
+		}
+		
+	mean_time_to_happen = { days = 5 }
+	
+	option = {
+		name = "EVT3697001OPTA"
+		300 = {
+			set_province_flag = big_ben_built
+			add_province_modifier = { name = the_big_ben duration = -1 }
+			}
+			prestige = 20
+		}
+	}
+	
+#country_event = {
+#
+#	id = 3697005
+#	title = "EVTNAME3697005" #The Canadian Borders - REMOVAL
+#	desc = "EVTDESC3697005"
+#	picture = "danishgovernment"
+#
+#	fire_only_once = yes
+#	
+#	trigger = {
+#		civilized = yes
+#		2599 = { NOT = { owned_by = THIS } empty = no }
+#		2630 = { NOT = { owned_by = THIS } empty = no }
+#		6 = { empty = yes }
+#		owns = 17
+#	}
+#		
+#	mean_time_to_happen = { days = 30 }
+#	
+#	option = {
+#		name = "EVT3697003OPTA"
+#		6 = { secede_province = THIS add_core = CAN any_pop = { literacy = -0.99 } }
+#		}
+#	}
+#	
+	
+country_event = {
+
+	id = 3697006
+	title = "EVTNAME3697006" #The Pioneer Column
+	desc = "EVTDESC3697006"
+	picture = "pioneer_column"
+
+	fire_only_once = yes
+	
+	trigger = {
+		OR = {
+			AND = {
+				2068 = { empty = yes }
+				2070 = { empty = yes }
+				2635 = { empty = yes }
+			}
+			AND = {
+				2068 = { owned_by = ENG }
+				2070 = { owned_by = ENG }
+				2635 = { owned_by = ENG }
+			}
+		}
+		tag = ENG
+		OR = {
+			2068 = { any_neighbor_province = { owned_by = THIS } }
+			2068 = { any_neighbor_province = { owner = { civilized = no in_sphere = THIS } } }
+		}
+		has_global_flag = berlin_conference
+		owns = 2087
+	}
+		
+	mean_time_to_happen = { days = 1 }
+	
+	option = {
+		name = "EVT3697006OPTA"
+		2070 = { secede_province = THIS life_rating = 25 any_pop = { limit = { NOT = { has_pop_culture = british } } literacy = -0.99 } }
+		2635 = { secede_province = THIS life_rating = 25 any_pop = { limit = { NOT = { has_pop_culture = british } } literacy = -0.99 } }
+		2068 = { secede_province = THIS change_province_name = "Salisbury" life_rating = 25 any_pop = { limit = { NOT = { has_pop_culture = british } } literacy = -0.99 } }
+		2073 = { secede_province = THIS life_rating = 10 any_pop = { limit = { NOT = { has_pop_culture = british } } literacy = -0.99 } }
+		2072 = { secede_province = THIS life_rating = 10 any_pop = { limit = { NOT = { has_pop_culture = british } } literacy = -0.99 } }
+		2096 = { any_pop = { limit = { type = soldiers has_pop_culture = british } move_pop = 2068 } }
+		2087 = { any_pop = { limit = { type = soldiers has_pop_culture = british } move_pop = 2068 } }
+		2087 = { any_pop = { limit = { type = artisans has_pop_culture = british } pop_type = soldiers } }
+	}
+}
+#Canada cores on Oregon and beyond
+country_event = {
+
+	id = 3697007
+	title = "EVTNAME3697007" 
+	desc = "EVTDESC3697007"
+	picture = "danishgovernment"
+
+	fire_only_once = yes
+	
+	trigger = {
+		tag = ENG
+		CAN = { 
+			exists = yes 
+			vassal_of = ENG
+			owns = 21
+			owns = 20
+			owns = 13
+			}
+		78 = { owned_by = THIS is_core = THIS is_core = COL }
+		79 = { owned_by = THIS is_core = THIS is_core = COL }
+		80 = { owned_by = THIS is_core = THIS is_core = COL }
+		81 = { owned_by = THIS is_core = THIS is_core = COL }
+		82 = { owned_by = THIS is_core = THIS is_core = COL }
+		83 = { owned_by = THIS is_core = THIS is_core = COL }
+	}
+		
+	mean_time_to_happen = { days = 1 }
+	
+	option = {
+		name = "EVT3697007OPTA"
+		relation = { who = CAN value = 100 }
+		diplomatic_influence = { who = CAN value = 100 }
+		badboy = -1
+		any_owned = {
+			limit = { is_core = COL }
+			secede_province = CAN
+			add_core = CAN
+			remove_core = THIS
+		}
+		ai_chance = { factor = 100 }
+	}
+	
+	option = {
+		name = "EVT3697007OPTB"
+		relation = { who = CAN value = -50 }
+		diplomatic_influence = { who = CAN value = -50 }
+		any_owned = {
+			limit = { is_core = COL }
+			remove_core = THIS
+		}
+		ai_chance = { factor = 0 }
+	}
+}	
+
+#Canada cores on Alaska
+country_event = {
+
+	id = 3697008
+	title = "EVTNAME3697008" 
+	desc = "EVTDESC3697008"
+	picture = "danishgovernment"
+
+	fire_only_once = yes
+	
+	trigger = {
+		tag = ENG
+		CAN = { 
+			exists = yes 
+			vassal_of = ENG
+			owns = 15
+			owns = 16
+			owns = 17
+			}
+		LSK  = { all_core = { owned_by = THIS } }
+	}
+		
+	mean_time_to_happen = { days = 1 }
+	
+	option = {
+		name = "EVT3697007OPTA"
+		relation = { who = CAN value = 100 }
+		diplomatic_influence = { who = CAN value = 100 }
+		badboy = -1
+		any_owned = {
+			limit = { is_core = LSK }
+			secede_province = CAN
+			add_core = CAN
+			remove_core = THIS
+		}
+		ai_chance = { factor = 100 }
+	}
+	
+	option = {
+		name = "EVT3697007OPTB"
+		relation = { who = CAN value = -50 }
+		diplomatic_influence = { who = CAN value = -50 }
+		any_owned = {
+			limit = { is_core = LSK }
+			remove_core = THIS
+		}
+		ai_chance = { factor = 0 }
+	}
+}
+
+#Selling Kashmir
+country_event = {
+
+	id = 3697009
+	title = "EVTNAME3697009" 
+	desc = "EVTDESC3697009"
+	picture = "kashmir_selling"
+
+	fire_only_once = yes
+	
+	trigger = {
+		tag = ENG
+		OR = {
+			ENG = {
+				owns = 1224
+				owns = 1225
+				owns = 1226
+			}
+			AND = {
+				EIC = {
+					owns = 1224
+					owns = 1225
+					owns = 1226		
+				}
+				EIC = { vassal_of = ENG }
+			}
+		}
+		war = no
+		NOT = { year = 1880 }
+		KAS = { exists = no }
+	}
+		
+	mean_time_to_happen = { months = 6 }
+	
+	option = {
+		name = "EVT3697009OPTA"
+			prestige = 5
+			badboy = -5
+			treasury = 50000
+			release = KAS
+			EIC = {
+				PAN_1224 = { secede_province = KAS }
+				release = KAS
+			}
+			create_vassal = KAS
+			diplomatic_influence = { who = KAS value = 400 }
+			relation = { who = KAS value = 400 }
+			KAS = {
+				civilized = no
+				government = absolute_monarchy 
+				any_pop = { militancy = 1 consciousness = 2 }
+				military_reform = yes_foreign_weapons
+				military_reform = yes_foreign_training
+				all_core = { remove_core = PNJ }
+			}
+		ai_chance = { factor = 100 }
+	}
+	
+	option = {
+		name = "EVT3697009OPTB"
+		any_owned = { limit = { OR = { is_core = PNJ is_core = KAS } } any_pop = { militancy = 4 consciousness = 6 } }
+		ai_chance = { factor = 0 }
+	}
+}
+
+#Durand Line
+country_event = {
+
+	id = 3697010
+	title = "EVTNAME3697010" 
+	desc = "EVTDESC3697010"
+	picture = "greatpowers"
+
+	is_triggered_only = yes
+	
+	option = {
+		name = "EVT3697010OPTA"
+			set_country_flag = durand_line
+			badboy = -2
+			relation = { who = ENG value = 400 }
+			treasury = 50000
+			HND = { all_core = { remove_core = AFG } }
+			any_owned = { limit = { is_core = HND } secede_province = ENG }
+			FROM = { diplomatic_influence = { who = THIS value = 50 } }
+			FROM = { any_owned = { limit = { is_core = AFG } secede_province = AFG } }
+			ENG = {		
+				diplomatic_influence = {
+					who = THIS
+					value = 100
+				}			
+			}
+			any_owned = {
+				limit = {
+					owner = { ai = yes neighbour = RUS }
+					OR = {
+						region = RUS_1196
+						region = KHI_1191
+						region = KOK_1190
+					}
+				}
+				secede_province = RUS
+			}
+			ai_chance = { 
+				factor = 95
+				modifier = {
+					factor = 100
+					OR = {
+						vassal_of = ENG
+						in_sphere = ENG
+					}
+				}
+			}
+	}
+	
+	option = {
+		name = "EVT3697010OPTB"
+		relation = { who = ENG value = -100 }
+		ai_chance = { factor = 5 }
+	}
+}
+
+#Sikkim Incident
+country_event = {
+
+	id = 3697011
+	title = "EVTNAME3697011" 
+	desc = "EVTDESC3697011"
+	picture = "sikkim_dalai_lama"
+
+	trigger = {
+		is_greater_power = yes
+		civilized = yes
+		SIK = {
+			ai = yes
+			exists = yes
+			civilized = no
+			OR = {
+				part_of_sphere = no
+				in_sphere = THIS
+			}
+			is_vassal = no
+		}
+		year = 1849
+		owns = 1252
+		NOT = { year = 1870 }
+	}
+	
+	fire_only_once = yes
+	
+	mean_time_to_happen = { months = 36 }
+	
+	option = {
+		name = "EVT3697011OPTA"
+			relation = { who = SIK value = -400 }
+			diplomatic_influence = { who = SIK value = -400 }
+			leave_alliance = THIS
+			casus_belli = { target = SIK type = make_puppet months = 30 }
+			war = {
+				target = SIK
+				attacker_goal = { casus_belli = make_puppet }
+				defender_goal = { casus_belli = humiliate }
+			}
+			SIK = { tech_school = unciv_tech_school }
+		ai_chance = { factor = 100 }
+	}
+	
+	option = {
+		name = "EVT3697011OPTB"
+		relation = { who = SIK value = -400 }
+		diplomatic_influence = { who = SIK value = -400 }
+		leave_alliance = THIS
+		random_country = {
+			limit = {
+				tag = SIK
+				exists = yes
+				neighbour = THIS
+				NOT = { number_of_states = 2 }
+				civilized = no
+			}
+			add_casus_belli = { target = THIS type = make_puppet months = 24 }
+		}
+		random_country = {
+			limit = {
+				tag = SIK
+				exists = yes
+				neighbour = THIS
+				NOT = { number_of_states = 2 }
+				civilized = yes
+			}
+			add_casus_belli = { target = THIS type = make_puppet months = 40 }
+		}
+		
+		ai_chance = { factor = 0 }
+	}
+}
+
+#Bahrain - Qatar War
+country_event = {
+
+	id = 3697012
+	title = "EVTNAME3697012" 
+	desc = "EVTDESC3697012"
+	picture = "bahrain_city"
+
+	trigger = {
+		tag = BHR
+		year = 1860
+		QAT = { exists = yes vassal_of = THIS }
+		ABU = { part_of_sphere = yes }
+	}
+	
+	fire_only_once = yes
+	
+	mean_time_to_happen = { months = 50 }
+	
+	immediate = { release_vassal = QAT }
+	
+	option = {
+		name = "EVT3697012OPTA"
+		ABU = { sphere_owner = { country_event = 3697013 } }
+		relation = { who =  QAT value = -400 }
+		1165 = { remove_core = BHR }
+		war = {
+			target = QAT
+			attacker_goal = {
+				casus_belli = conquest_any
+			}
+			defender_goal = {
+				casus_belli = status_quo
+			}
+		
+		}
+	}
+}
+
+#Bahrain - Qatar War - Foreign Intervention
+country_event = {
+
+	id = 3697013
+	title = "EVTNAME3697012" 
+	desc = "EVTDESC3697013"
+	picture = "bahrain_city"
+
+	is_triggered_only = yes
+	
+	option = {
+		name = "EVT3697013OPTA"
+		relation = { who =  BHR value = -400 }
+		diplomatic_influence = { who =  BHR value = -400 }
+		relation = { who = QAT value = 400 }
+		diplomatic_influence = { who = QAT value = 400 }
+		random_country = {
+			limit = {
+				vassal_of = THIS
+				exists = yes
+				tag = BHR
+				}
+		THIS = { release_vassal = BHR }
+		}
+		
+		casus_belli = {
+			target = BHR
+			type = add_to_sphere
+			months = 60
+		}
+		ai_chance = { factor = 0 }
+	}
+	option = {
+		name = "EVT3697013OPTB"
+		relation = { who =  BHR value = -400 }
+		diplomatic_influence = { who =  BHR value = -400 }
+		relation = { who = QAT value = 400 }
+		diplomatic_influence = { who = QAT value = 400 }
+		random_country = {
+			limit = {
+				vassal_of = THIS
+				exists = yes
+				tag = BHR
+				}
+		THIS = { release_vassal = BHR }
+		}
+		
+		casus_belli = {
+			target = BHR
+			type = add_to_sphere
+			months = 60
+		}
+		
+		war = {
+			target = BHR
+			attacker_goal = {
+				casus_belli = add_to_sphere
+				}
+			defender_goal = {
+				casus_belli = status_quo
+				}
+			}
+		ai_chance = { factor = 100 }
+	}
+	
+	option = {
+		name = "EVT3697013OPTC"
+		prestige = -5
+		ai_chance = { factor = 0 }
+	}
+}
+
+#UK relations in Arabia
+country_event = {
+
+	id = 3697014
+	title = "EVTNAME3697014" 
+	desc = "EVTDESC3697014"
+	picture = "bahrain_city"
+
+	trigger = {
+		owns = 1173
+		owns = 1175
+		is_greater_power = yes
+		}
+		
+	fire_only_once = yes
+	mean_time_to_happen = { days = 1 }
+	
+	option = {
+		name = "EVT3697014OPTA"
+		random_country = { limit = { exists = yes tag = OMA } relation = { who = THIS value = 400 } }
+		random_country = { limit = { exists = yes tag = NEJ } relation = { who = THIS value = 400 } }
+		random_country = { limit = { exists = yes tag = HAL } relation = { who = THIS value = 400 } }
+		ai_chance = { factor = 100 }
+	}
+	option = {
+		name = "EVT3697014OPTB"
+		ai_chance = { factor = 0 }
+	}
+}
+
+#Welcome Stranger
+country_event = {
+
+	id = 113901
+	title = "EVTNAME113901"
+	desc = "EVTDESC113901"
+	picture = "welcome_stranger_nugget"
+
+	trigger = {
+		owns = 2478
+		year = 1850
+		2478 = { NOT = { trade_goods = precious_metal } }
+		NOT = { year = 1890 }
+	}
+	
+	mean_time_to_happen = { months = 24 }
+	
+	fire_only_once = yes
+	
+	option = {
+		name = "EVTOPTA113901"
+		prestige = 2
+		2478 = { trade_goods = precious_metal add_province_modifier = { name = gold_rush duration = 730 } }
+		2601 = { life_rating = -5 change_province_name = "Sandy Desert" }
+		2605 = { life_rating = -5 change_province_name = "Gibson's Desert"}
+		2507 = { life_rating = -5 change_province_name = "Alice Springs" }
+		2603 = { life_rating = -5 change_province_name = "Tanami" }
+		2495 = { change_province_name = "Angle Pole" }
+		2476 = { trade_goods = precious_metal add_province_modifier = { name = gold_rush duration = 730 } life_rating = 5 }
+		2468 = {
+			trade_goods = coal
+			#remove_province_modifier = local_tractors
+			life_rating = 10
+			add_province_modifier = { name = gateway_to_harbor duration = 1825 }
+		}
+		
+		AST = { capital = 2468 }
+	}
+}
+
+#The End of the Gold Rush
+province_event = {
+
+	id = 315001
+	title = "EVTNAME315001"
+	desc = "EVTDESC315001"
+	
+	trigger = {
+		trade_goods = precious_metal
+		OR = {
+			province_id = 2478
+			province_id = 2481
+			province_id = 2472
+			province_id = 2470
+			province_id = 2334
+			province_id = 2400
+		}
+		year = 1875
+	}
+ 
+	mean_time_to_happen = {
+		months = 24
+		modifier = {
+			factor = 10000
+			province_id = 2478
+			NOT = { year = 1900 }
+		}
+		modifier = {
+			factor = 10000
+			OR = {
+				province_id = 2478
+				province_id = 2481
+				province_id = 2472
+				province_id = 2470
+			}
+			NOT = { year = 1890 }
+		}
+		modifier = {
+			factor = 10000
+			OR = {
+				province_id = 2334
+				province_id = 2400
+			}
+			NOT = { year = 1905 }
+		}
+	}
+	
+	immediate = { trade_goods = grain }
+
+	option = {
+		name = "EVTOPTA315001"
+		owner = { random_owned = { limit = { owner = { owns = 2492 2492 = { NOT = { trade_goods = iron } } } }
+			owner = { 2492 = { trade_goods = iron } }
+			}
+		}
+		
+		owner = { random_owned = { limit = { owner = { owns = 2484 2484 = { NOT = { trade_goods = coal } } } }
+			owner = { 2484 = { trade_goods = coal } }
+			}
+		}
+		
+		owner = { random_owned = { limit = { owner = { owns = 2481 2481 = { trade_goods = grain } } }
+			owner = { 2481 = { trade_goods = coal } }
+			}
+		}
+		
+		owner = { random_owned = { limit = { owner = { owns = 2472 2472 = { trade_goods = grain } } }
+			owner = { 2472 = { trade_goods = coal } }
+			}
+		}
+		
+		owner = { random_owned = { limit = { owner = { owns = 2470 2470 = { trade_goods = grain } } }
+			owner = { 2470 = { trade_goods = coal } }
+			}
+		}
+
+		owner = { random_owned = { limit = { owner = { owns = 2494 2494 = { NOT = { trade_goods = iron } } } }
+			owner = { 2494 = { trade_goods = iron } }
+			}
+		}
+		
+		owner = { random_owned = { limit = { owner = { owns = 2495 2495 = { NOT = { trade_goods = iron } } } }
+			owner = { 2495 = { trade_goods = iron } }
+			}
+		}
+		
+		owner = { random_owned = { limit = { owner = { owns = 2495 2495 = { NOT = { trade_goods = iron } } } }
+			owner = { 2495 = { trade_goods = iron } }
+			}
+		}
+		
+		owner = { random_owned = { limit = { owner = { owns = 2475 2475 = { NOT = { trade_goods = iron } } } }
+			owner = { 2475 = { trade_goods = iron } }
+			}
+		}
+		
+		owner = { random_owned = { limit = { owner = { owns = 2473 2473 = { NOT = { trade_goods = iron } } } }
+			owner = { 2473 = { trade_goods = iron } }
+			}
+		}
+		
+		owner = { random_owned = { limit = { owner = { owns = 2483 2483 = { NOT = { trade_goods = iron } } } }
+			owner = { 2483 = { trade_goods = iron } }
+			}
+		}
+		
+		owner = { random_owned = { limit = { owner = { owns = 2489 2489 = { NOT = { trade_goods = iron } } } }
+			owner = { 2489 = { trade_goods = iron } }
+			}
+		}
+		
+		owner = { random_owned = { limit = { owner = { owns = 2487 2487 = { NOT = { trade_goods = iron } } } }
+			owner = { 2487 = { trade_goods = iron } }
+			}
+		}
+		
+		owner = { random_owned = { limit = { owner = { owns = 2482 2482 = { NOT = { trade_goods = iron } } } }
+			owner = { 2482 = { trade_goods = iron } }
+			}
+		}
+		
+		owner = { random_owned = { limit = { owner = { owns = 2400 2400 = { NOT = { trade_goods = wool } } } }
+			owner = { 2400 = { trade_goods = wool } }
+			}
+		}
+		
+		owner = { random_owned = { limit = { owner = { owns = 2334 2334 = { NOT = { trade_goods = wool } } } }
+			owner = { 2334 = { trade_goods = wool } }
+			}
+		}
+	}
+}
+
+#The Second Anglo-Ashanti War
+country_event = {
+
+	id = 315002
+	title = "EVTNAME315002"
+	desc = "EVTDESC315002"
+	picture = "anglo_ashanti_war"
+	
+	trigger = {
+		owns = 1908
+		nationalism_n_imperialism = 1
+		ASH = { civilized = no exists = yes neighbour = THIS owns = 1907 ai = yes }
+	}
+	
+	fire_only_once = yes
+ 
+	mean_time_to_happen = { months = 100 }
+
+	option = {
+		name = "EVTOPTA315002" 
+		relation = { who = ASH value = -400 }
+		diplomatic_influence = { who = ASH value = -400 }
+		casus_belli = {
+	        target = ASH
+			type = demand_concession_NI_casus_belli
+			months = 60
+		}
+		casus_belli = {
+	        target = ASH
+			type = demand_concession_BC_casus_belli
+			months = 60
+		}
+		casus_belli = {
+	        target = ASH
+			type = add_to_sphere
+			months = 60
+		}
+		ai_chance = { factor = 95 }
+	}
+	
+	option = {
+		name = "EVTOPTB315002" 
+		relation = { who = ASH value = 50 }
+		ai_chance = { factor = 5 }
+	}
+}
+
+#Turning a few pops
+country_event = {
+
+	id = 315003
+	title = "EVTNAME315003"
+	desc = "EVTDESC315003"
+	picture = "glasgow_bridge"
+	
+	trigger = {
+		tag = SCO
+		NOT = { any_pop = { has_pop_culture = scottish } }
+	}
+	
+	fire_only_once = yes
+	
+	immediate = { primary_culture = scottish }
+ 
+	mean_time_to_happen = { months = 2 }
+
+	option = {
+		name = "EVTOPTA315003"
+		random_owned = { limit = { is_capital = yes } assimilate = yes }
+		any_pop = { limit = { NOT = { is_primary_culture = yes } } militancy = 3 consciousness = 4 }
+		any_owned = { limit = { is_core = THIS } add_province_modifier = { name = cultural_resurgence duration = 3650 } }
+	}
+}
+
+#David Livingstone is Found
+country_event = {
+
+	id = 315004
+	title = "EVTNAME315004"
+	desc = "EVTDESC315004"
+	news = yes
+	news_desc_long = "EVTDESC315004_NEWS_LONG"
+	news_desc_medium = "EVTDESC315004_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC315004_NEWS_SHORT"
+	picture = "dr_livingstone"
+	
+	trigger = {
+		tag = USA
+		exists = yes
+		has_global_flag = american_civil_war_has_happened
+		year = 1871
+		war = no
+	}
+	
+	fire_only_once = yes
+	 
+	mean_time_to_happen = {
+		months = 12
+		modifier = { factor = 0.25 month = 10 }
+	}
+
+	option = {
+		name = "EVTOPTA315004"
+		random_owned = { limit = { owner = { tag = ENG } } owner = { prestige = 15 relation = { who = USA value = 10 } } }
+		random_owned = { limit = { owner = { tag = USA } }
+			owner = {
+				prestige = 15
+				relation = { who = ENG value = 10 }
+				ENG = { country_event = 315004 }
+			}
+		}
+	}
+}
+
+# Paulet Affair
+country_event = {
+		
+	id = 110081
+	title = "EVTNAME110081" #Paulet Affair
+	desc = "EVTDESC110081"
+	picture = "ENG_paulet_affair"
+
+	trigger = {
+		tag = ENG
+		year = 1843
+		nationalism_n_imperialism = 1
+		HAW = { 
+			exists = yes 
+			is_vassal = no
+			part_of_sphere = no		
+		}
+	}
+
+	fire_only_once = yes
+	mean_time_to_happen = {
+		months = 36 #Three years
+		modifier = {
+			factor = 1.50
+			relation = { who = USA value = 100 }
+		}
+	}
+	
+	option = {
+		name = "EVT110081OPTA" #Support Paulet!
+		badboy = 5
+		inherit = HAW
+		relation = { who = USA value = -200 }
+		USA = {
+			casus_belli = {
+				target = ENG
+				type = free_peoples
+				months = 30
+			}
+			casus_belli = {
+				target = ENG
+				type = humiliate
+				months = 30
+			}
+		}
+		
+		ai_chance = { factor = 2 }
+	}
+		
+	option = {
+		name = "EVT110081OPTB" #Demand compensation.
+		badboy = 1
+		treasury = 2500
+		HAW = { treasury = -2500 }
+		relation = { who = USA value = -100 }
+		relation = { who = HAW value = -200 }
+		diplomatic_influence = { who = HAW value = 400 }
+				
+		ai_chance = { factor = 18 }
+	}
+		
+	option = {
+		name = "EVT110081OPTC" #Drop the case entirely.
+		badboy = -1
+		prestige = -5
+		relation = { who = HAW value = 50 }
+		relation = { who = USA value = 50 }
+		
+		ai_chance = { factor = 80 }
+	}
+}
+
+# From Hell
+country_event = {
+	id = 110078
+	title = "EVTNAME110078"
+	desc = "EVTDESC110078"
+	picture = "ENG_from_hell"
+	news = yes
+	news_title = "EVTNAME110078_NEWS_TITLE"
+	news_desc_long = "EVTDESC110078_NEWS_LONG"
+	news_desc_medium = "EVTDESC110078_NEWS_MEDIUM"
+	news_desc_short = "EVTDESC110078_NEWS_SHORT"
+	
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		}
+		owns = 300 #London
+		year = 1888
+		NOT = { year = 1890 }
+		NOT = { crime_fighting = 0.75 } 
+	}
+		
+	mean_time_to_happen = { months = 12 }
+	fire_only_once = yes
+	
+	option = {
+		name = "EVT110078OPTA" #So what? Crimes happen everyday.
+		set_country_flag = from_hell
+		300 = {
+			add_province_modifier = { name = serial_killer duration = 730 }
+			any_pop = {	
+				limit = { strata = poor }
+				militancy = 5
+				consciousness = 5
+			}
+		}
+	}
+}
+
+# Jack the Ripper caught!
+country_event = {
+	id = 110079
+	title = "EVTNAME110079"
+	desc = "EVTDESC110079"
+	picture = "ENG_from_hell"
+	
+	trigger = {
+		OR = {
+			tag = ENG
+			tag = ENL
+		}
+		300 = {
+			has_province_modifier = serial_killer
+		}
+		owns = 300 #London
+		crime_fighting = 0.95
+		NOT = { year = 1890 }
+		has_country_flag = from_hell
+		has_country_flag = elementary_my_dear_watson #Scotland Yard
+		has_country_modifier = the_yard
+		OR = {
+			government = absolute_monarchy
+			government = prussian_constitutionalism
+			government = hms_government
+		}
+	}
+		
+	mean_time_to_happen = { 
+		months = 200
+	}
+	fire_only_once = yes
+	
+	option = {
+		name = "EVT110079OPTA" #My congratulations to Scotland Yard!
+		clr_country_flag = from_hell
+		prestige = -15
+		300 = {
+			any_pop = {	
+				limit = { 
+					strata = poor
+				}
+				militancy = -9
+				consciousness = -9
+			}
+			any_pop = {	
+				limit = { 
+					strata = rich
+				}
+				militancy = 9
+				consciousness = 9
+			}
+			remove_province_modifier = serial_killer
+		}
+	}
+	
+	option = {
+		name = "EVT110079OPTB" #This is not getting out of this room.
+		clr_country_flag = from_hell
+		300 = {
+			any_pop = {	
+				limit = {
+					OR = {
+						strata = poor
+						strata = middle
+					}
+				}
+				militancy = 5
+				consciousness = 3
+			}
+			any_pop = {	
+				limit = { 
+					strata = rich
+				}
+				militancy = -9
+				consciousness = -9
+			}
+			remove_province_modifier = serial_killer
+		}
+	}
+}
+
+# Basotho/Suazi Asks for Protection
+country_event = {
+	id = 110080
+	title = "EVTNAME110080"
+	desc = "EVTDESC110080"
+	picture = "scramble_for_africa"
+	
+	is_triggered_only = yes
+	
+	option = {
+		name = "EVT110080OPTA" #They will become our subjects
+		prestige = 2
+		random_country = {
+			limit = { tag = FROM primary_culture = sotho }
+			all_core = { remove_core = BSH }
+			any_owned = { limit = { NOT = { is_capital = yes } } secede_province = THIS }
+			tech_school = unciv_tech_school
+			research_points = -5000
+			remove_accepted_culture = nguni
+			set_country_flag = post_colonial_country
+			clr_country_flag = sunni_country
+			clr_country_flag = shiite_country
+			clr_country_flag = ibadi_country
+			clr_country_flag = catholic_country
+			clr_country_flag = protestant_country
+			clr_country_flag = mormon_country
+			clr_country_flag = orthodox_country
+			clr_country_flag = coptic_country
+			clr_country_flag = jewish_country
+			clr_country_flag = yazidi_country
+			clr_country_flag = mahayana_country
+			clr_country_flag = gelugpa_country
+			clr_country_flag = theravada_country
+			clr_country_flag = hindu_country
+			clr_country_flag = shinto_country
+			clr_country_flag = sikh_country
+			clr_country_flag = animist_country
+			neutrality = yes
+			2104 = { add_core = BSH }
+		}
+		
+		random_country = {
+			limit = { tag = FROM primary_culture = nguni }
+			all_core = { remove_core = SUA }
+			any_owned = { limit = { NOT = { is_capital = yes } } secede_province = THIS }
+			tech_school = unciv_tech_school
+			research_points = -5000
+			remove_accepted_culture = zulu
+			set_country_flag = post_colonial_country
+			clr_country_flag = sunni_country
+			clr_country_flag = shiite_country
+			clr_country_flag = ibadi_country
+			clr_country_flag = catholic_country
+			clr_country_flag = protestant_country
+			clr_country_flag = mormon_country
+			clr_country_flag = orthodox_country
+			clr_country_flag = coptic_country
+			clr_country_flag = jewish_country
+			clr_country_flag = yazidi_country
+			clr_country_flag = mahayana_country
+			clr_country_flag = gelugpa_country
+			clr_country_flag = theravada_country
+			clr_country_flag = hindu_country
+			clr_country_flag = shinto_country
+			clr_country_flag = sikh_country
+			clr_country_flag = animist_country
+			neutrality = yes
+			2114 = { add_core = SUA trade_goods = coal }
+		}
+		random_country = {
+			limit = { tag = FROM primary_culture = sotho }
+			THIS = { create_vassal = BSH }
+		}
+		
+		random_country = {
+			limit = { tag = FROM primary_culture = nguni }
+			THIS = { create_vassal = SUA }
+		}
+		
+		relation = { who = FROM value = 200 }
+		diplomatic_influence = { who = FROM value = 200 }
+			
+		random_owned = { limit = { owner = { has_country_flag = catholic_country } } FROM = { religion = catholic set_country_flag = catholic_country } }
+		random_owned = {
+			limit = { owner = { has_country_flag = protestant_country } }
+			FROM = { religion = protestant set_country_flag = protestant_country }
+		}
+		random_owned = { limit = { owner = { has_country_flag = orthodox_country } } FROM = { religion = orthodox set_country_flag = orthodox_country } }
+		random_owned = { limit = { owner = { has_country_flag = mormon_country } } FROM = { religion = mormon set_country_flag = mormon_country } }
+		random_owned = { limit = { owner = { has_country_flag = coptic_country } } FROM = { religion = coptic set_country_flag = coptic_country } }
+		random_owned = { limit = { owner = { has_country_flag = sunni_country } } FROM = { religion = sunni set_country_flag = sunni_country } }
+		random_owned = { limit = { owner = { has_country_flag = shiite_country } } FROM = { religion = shiite set_country_flag = shiite_country } }
+		random_owned = { limit = { owner = { has_country_flag = shinto_country } } FROM = { religion = shinto set_country_flag = shinto_country } }
+		random_owned = { limit = { owner = { has_country_flag = mahayana_country } } FROM = { religion = mahayana set_country_flag = mahayana_country } }
+		random_owned = { limit = { owner = { has_country_flag = gelugpa_country } } FROM = { religion = gelugpa set_country_flag = gelugpa_country } }
+		random_owned = { limit = { owner = { has_country_flag = theravada_country } } FROM = { religion = theravada set_country_flag = theravada_country } }
+		random_owned = { limit = { owner = { has_country_flag = hindu_country } } FROM = { religion = hindu set_country_flag = hindu_country } }
+		random_owned = { limit = { owner = { has_country_flag = sikh_country } } FROM = { religion = sikh set_country_flag = sikh_country } }
+		random_owned = { limit = { owner = { has_country_flag = jewish_country } } FROM = { religion = jewish set_country_flag = jewish_country } }
+		random_owned = { limit = { owner = { has_country_flag = ibadi_country } } FROM = { religion = ibadi set_country_flag = ibadi_country } }
+		random_owned = { limit = { owner = { has_country_flag = yazidi_country } } FROM = { religion = yazidi set_country_flag = yazidi_country } }
+		
+		random_owned = { limit = { slavery = no_slavery } FROM = { political_reform = no_slavery } }
+		
+		any_country = { limit = { primary_culture = boer is_vassal = no } relation = { who = THIS value = -50 } }
+		
+		ai_chance = {
+			factor = 80
+			modifier = { factor = 10 relation = { who = FROM value = 100 } }
+		}
+	}
+	
+	option = {
+		name = "EVT110080OPTB" #Let them fend off for themselves
+		relation = { who = FROM value = -400 }
+		diplomatic_influence = { who = FROM value = -400 }
+		ai_chance = {
+			factor = 20
+			modifier = { factor = 0 relation = { who = FROM value = 150 } }
+		}
+	}
+}
+

--- a/Megamp/events/East Indies.txt
+++ b/Megamp/events/East Indies.txt
@@ -1,0 +1,1279 @@
+#####################################################
+#                                                    #
+#            East Indies Events                        #
+#                                                    #
+#####################################################
+
+
+country_event = {
+    id = 95250
+    title = "EVTNAME95250" #The White Rajah
+    desc = "EVTDESC95250"
+    news = yes
+    news_desc_long = "EVTDESC95250_NEWS_LONG"
+    news_desc_medium = "EVTDESC95250_NEWS_MEDIUM"
+    news_desc_short = "EVTDESC95250_NEWS_SHORT"
+    picture = "white_rajah"
+
+    trigger = {
+        tag = BRU
+        war = no
+        part_of_sphere = no
+        civilized = no
+        owns = 1394
+        owns = 1395
+        year = 1841
+    }
+
+    fire_only_once = yes
+
+    mean_time_to_happen = {
+        months = 6
+    }
+
+    option = {
+        name = "EVT95250OPTA"
+        prestige = -5
+        1394 = {
+            add_core = SWK
+            remove_core = BRU
+            secede_province = SWK
+        }
+        1395 = {
+            add_core = SWK
+            remove_core = BRU
+            secede_province = SWK
+        }
+        random_country = {
+            limit = {
+                tag = ENG
+                exists = yes
+            }
+            diplomatic_influence = {
+                who = SWK
+                value = 300
+            }
+            diplomatic_influence = {
+                who = BRU
+                value = 200
+            }
+        }
+        relation = {
+            who = SWK
+            value = 100
+        }
+        create_alliance = SWK
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = yes
+                }
+                SWK = { civilized = yes }
+            }
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    land_reform = yes_land_reform
+                }
+                SWK = { economic_reform = yes_land_reform }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    admin_reform = yes_admin_reform
+                }
+                SWK = { economic_reform = yes_admin_reform }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    finance_reform = yes_finance_reform
+                }
+                SWK = { economic_reform = yes_finance_reform }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    finance_reform = finance_reform_two
+                }
+                SWK = { economic_reform = finance_reform_two }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    monetary_reform = yes_monetary_reform
+                }
+                SWK = { economic_reform = yes_monetary_reform }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    monetary_reform = yes_monetary_reform
+                }
+                SWK = { economic_reform = monetary_reform_two activate_technology = no_standard }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    education_reform = yes_education_reform
+                }
+                SWK = { economic_reform = yes_education_reform }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    research_reform = yes_research_reform
+                }
+                SWK = { economic_reform = yes_research_reform activate_technology = late_enlightenment_philosophy }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    foreign_training = yes_foreign_training
+                }
+                SWK = { military_reform = yes_foreign_training }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    foreign_weapons = yes_foreign_weapons
+                }
+                SWK = { military_reform = yes_foreign_weapons activate_technology = flintlock_rifles }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    foreign_officers = yes_foreign_officers
+                }
+                SWK = { military_reform = yes_foreign_officers activate_technology = military_staff_system }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    army_schools = yes_army_schools
+                }
+                SWK = { military_reform = yes_army_schools }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    foreign_naval_officers = yes_foreign_naval_officers
+                }
+                SWK = { military_reform = yes_foreign_naval_officers }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    naval_schools = yes_naval_schools
+                }
+                SWK = { military_reform = yes_naval_schools }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    foreign_navies = yes_foreign_navies
+                }
+                SWK = { military_reform = yes_foreign_navies activate_technology = clipper_design activate_technology = steamers set_country_flag = using_foreign_ships }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    western_shipyards = yes_western_shipyards
+                }
+                SWK = { military_reform = yes_western_shipyards activate_technology = post_nelsonian_thought }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    foreign_artillery = yes_foreign_artillery
+                }
+                SWK = { military_reform = yes_foreign_artillery activate_technology = bronze_muzzle_loaded_artillery }
+            }
+
+            random_owned = {
+                limit = { owner = { civilized = no slavery = yes_slavery } }
+                SWK = { political_reform = yes_slavery }
+            }
+
+            random_owned = {
+                limit = { owner = { civilized = no slavery = freedom_of_womb } }
+                SWK = { political_reform = freedom_of_womb }
+            }
+
+            random_owned = {
+                limit = { owner = { civilized = no slavery = no_slavery } }
+                SWK = { political_reform = no_slavery }
+            }
+        ai_chance = {
+            factor = 90
+        }
+    }
+
+    option = {
+        name = "EVT95250OPTB"
+        prestige = 5
+        1394 = {
+            add_core = SWK
+            secede_province = SWK
+        }
+        1395 = {
+            add_core = SWK
+            secede_province = SWK
+        }
+        random_country = {
+            limit = {
+                tag = ENG
+                exists = yes
+            }
+            diplomatic_influence = {
+                who = SWK
+                value = 100
+            }
+        }
+
+        random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = yes
+                }
+                SWK = { civilized = yes }
+            }
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    land_reform = yes_land_reform
+                }
+                SWK = { economic_reform = yes_land_reform }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    admin_reform = yes_admin_reform
+                }
+                SWK = { economic_reform = yes_admin_reform }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    finance_reform = yes_finance_reform
+                }
+                SWK = { economic_reform = yes_finance_reform }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    finance_reform = finance_reform_two
+                }
+                SWK = { economic_reform = finance_reform_two }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    monetary_reform = yes_monetary_reform
+                }
+                SWK = { economic_reform = yes_monetary_reform }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    monetary_reform = yes_monetary_reform
+                }
+                SWK = { economic_reform = monetary_reform_two activate_technology = no_standard }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    education_reform = yes_education_reform
+                }
+                SWK = { economic_reform = yes_education_reform }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    research_reform = yes_research_reform
+                }
+                SWK = { economic_reform = yes_research_reform activate_technology = late_enlightenment_philosophy }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    foreign_training = yes_foreign_training
+                }
+                SWK = { military_reform = yes_foreign_training }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    foreign_weapons = yes_foreign_weapons
+                }
+                SWK = { military_reform = yes_foreign_weapons activate_technology = flintlock_rifles }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    foreign_officers = yes_foreign_officers
+                }
+                SWK = { military_reform = yes_foreign_officers activate_technology = military_staff_system }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    army_schools = yes_army_schools
+                }
+                SWK = { military_reform = yes_army_schools }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    foreign_naval_officers = yes_foreign_naval_officers
+                }
+                SWK = { military_reform = yes_foreign_naval_officers }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    naval_schools = yes_naval_schools
+                }
+                SWK = { military_reform = yes_naval_schools }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    foreign_navies = yes_foreign_navies
+                }
+                SWK = { military_reform = yes_foreign_navies activate_technology = clipper_design activate_technology = steamers set_country_flag = using_foreign_ships }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    western_shipyards = yes_western_shipyards
+                }
+                SWK = { military_reform = yes_western_shipyards activate_technology = post_nelsonian_thought }
+            }
+
+            random_country = {
+                limit = {
+                    tag = BRU
+                    civilized = no
+                    foreign_artillery = yes_foreign_artillery
+                }
+                SWK = { military_reform = yes_foreign_artillery activate_technology = bronze_muzzle_loaded_artillery }
+            }
+
+            random_owned = {
+                limit = { owner = { civilized = no slavery = yes_slavery } }
+                SWK = { political_reform = yes_slavery }
+            }
+
+            random_owned = {
+                limit = { owner = { civilized = no slavery = freedom_of_womb } }
+                SWK = { political_reform = freedom_of_womb }
+            }
+
+            random_owned = {
+                limit = { owner = { civilized = no slavery = no_slavery } }
+                SWK = { political_reform = no_slavery }
+            }
+
+        war = {
+            target = SWK
+            attacker_goal = {
+                casus_belli = civil_war
+            }
+
+            defender_goal = {
+                casus_belli = status_quo
+            }
+        }
+        ai_chance = {
+            factor = 10
+            modifier = {
+                factor = 0
+                NOT = { total_amount_of_divisions = 2 }
+            }
+        }
+    }
+}
+
+# Event to Inherit
+country_event = {
+    id = 95255
+    title = "EVTNAME95255" #Indonesian Unification
+    desc = "EVTDESC95255"
+    picture = "Celebration"
+
+    is_triggered_only = yes
+
+    option = {
+        name = "EVT95255OPTA"
+        random_country = {
+            limit = {
+                NOT = { is_our_vassal = THIS }
+                is_sphere_leader_of = THIS
+            }
+            relation = {
+                who = FROM
+                value = -25
+            }
+        }
+        random_country = {
+            limit = { is_our_vassal = THIS }
+            casus_belli = {
+                target = FROM
+                type = acquire_state
+                months = 12
+            }
+            casus_belli = {
+                target = FROM
+                type = cut_down_to_size
+                months = 12
+            }
+            relation = {
+                who = FROM
+                value = -50
+            }
+            FROM = { badboy = 1 }
+        }
+        FROM = { inherit = THIS }
+        ai_chance = {
+            factor = 80
+            modifier = {
+                factor = 0.5
+                is_vassal = yes
+            }
+            modifier = {
+                factor = 0.5
+                part_of_sphere = yes
+                NOT = { in_sphere = FROM }
+            }
+            modifier = {
+                factor = 0.5
+                NOT = {
+                    relation = {
+                        who = FROM
+                        value = 100
+                    }
+                }
+            }
+            modifier = {
+                factor = 1.2
+                alliance_with = FROM
+            }
+        }
+    }
+
+    option = {
+        name = "EVT95255OPTB"
+        prestige = 1
+        relation = {
+            who = FROM
+            value = -100
+        }
+        leave_alliance = FROM
+        any_pop = {
+            militancy = 3
+            consciousness = 2
+        }
+        ai_chance = {
+            factor = 20
+            modifier = {
+                factor = 2
+                is_vassal = yes
+            }
+            modifier = {
+                factor = 2
+                part_of_sphere = yes
+                NOT = { in_sphere = FROM }
+            }
+            modifier = {
+                factor = 0
+                in_sphere = FROM
+            }
+            modifier = {
+                factor = 0
+                vassal_of = FROM
+            }
+        }
+    }
+}
+
+
+country_event = {
+    id = 97125
+    title = "EVTNAME97125" #Flores Purchase
+    desc = "EVTDESC97125"
+    picture = "treaty"
+
+    is_triggered_only = yes
+
+    option = {
+        name = "EVT97125OPTA"
+        prestige = 5
+        relation = { who = POR value = 200 }
+        random_owned = {
+            limit = {
+                owner = {
+                    NOT = { money = 100000 }
+                    check_variable = { which = owed_cash_money value = 9 }
+                }
+            }
+            owner = { change_variable = { which = owed_cash_money value = 100 } }
+        }
+        random_owned = {
+            limit = {
+                owner = {
+                    NOT = { money = 100000 }
+                    NOT = { check_variable = { which = owed_cash_money value = 1 } }
+                }
+            }
+            owner = { set_variable = { which = owed_cash_money value = 100 } }
+        }
+        random_owned = {
+            limit = { owner = { money = 100000 } }
+            owner = { treasury = -100000 }
+        }
+
+        POR = {
+            money = 100000
+            any_owned = {
+                limit = {
+                    OR = {
+                        province_id = 1439
+                        province_id = 1444
+                    }
+                }
+                secede_province = THIS
+            }
+        }
+        ai_chance = { factor = 95 }
+    }
+
+    option = {
+        name = "EVT97125OPTB"
+        prestige = -5
+        relation = {
+            who = POR
+            value = -15
+        }
+        ai_chance = {
+            factor = 5
+        }
+    }
+}
+
+## Indonesian colony spread
+province_event = {
+    id = 97130
+    title = "EVTNAME98800"
+    desc = "EVTDESC97130"
+
+    trigger = {
+        OR = {
+            region = BAL_1438 #Bali
+            region = NET_1398 #Djambi
+            region = NET_1401 #Siak
+            region = ATJ_1405 #Atjeh
+            region = NET_1426 #South Borneo
+            region = NET_1423 #East Borneo
+            region = BRU_1396 #North Borneo
+            region = BRU_1394 #West Borneo
+            region = NET_1446 #Timor
+            region = NET_1449 #Celebes
+            region = NET_1447 #Mollucas
+            region = NET_1451 #Western New Guinea
+            region = AST_2528 #Southern New Guina
+            region = GER_2530 #Northern New Guinea
+        }
+        owned_by = THIS
+        controlled_by = THIS
+        any_neighbor_province = {
+            is_core = INO
+        }
+        owner = {
+            civilized = yes
+            NOT = { is_culture_group = southeast_asian }
+        }
+        OR = {
+            AND = {
+                owner = { owns = 1413 }
+                INO = { exists = no }
+            }
+            INO = {
+                vassal_of = THIS
+                is_culture_group = THIS
+            }
+        }
+        NOT = {
+            is_core = INO
+        }
+    }
+
+    mean_time_to_happen = {
+        months = 60
+    }
+
+    option = {
+        name = "EVT97130OPTA"
+        state_scope = {
+            any_owned = {
+                limit = { NOT = { is_core = INO } }
+                add_core = INO
+                any_pop = { militancy = -3 }
+                add_province_modifier = {
+                    name = colonial_exploitation
+                    duration = 1095
+                }
+            }
+        }
+        INO = { add_accepted_culture = malay }
+        state_scope = {
+            any_owned = {
+                limit = { is_core = INO NOT = { province_id = 1446 } }
+                remove_core = JAV
+                remove_core = DJA
+                remove_core = SAK
+                remove_core = ATJ
+                remove_core = BAL
+                remove_core = SLW
+                remove_core = MAL
+                remove_core = KLM
+                remove_core = LAN
+                remove_core = PNK
+                remove_core = KTI
+                remove_core = SUL
+                remove_core = BRU
+            }
+        }
+    }
+}
+
+province_event = {
+    id = 97131
+    title = "EVTNAME98800"
+    desc = "EVTDESC97130"
+
+    trigger = {
+        OR = {
+            region = NET_1446 #Flores
+            region = NET_1449 #Sulawesi
+            region = NET_1447 #Moluccas
+        }
+        owned_by = THIS
+        controlled_by = THIS
+        any_neighbor_province = {
+            is_core = INO
+        }
+        owner = {
+            civilized = yes
+            NOT = { is_culture_group = southeast_asian }
+        }
+        OR = {
+            AND = {
+                owner = { owns = 1413 }
+                INO = { exists = no }
+            }
+            INO = {
+                vassal_of = THIS
+                is_culture_group = THIS
+            }
+        }
+        NOT = {
+            is_core = INO
+        }
+    }
+
+    mean_time_to_happen = {
+        months = 60
+    }
+
+    option = {
+        name = "EVT97130OPTA"
+        state_scope = {
+            any_owned = {
+                limit = {
+                    NOT = { is_core = INO }
+                }
+                add_core = INO
+                any_pop = { militancy = -3 }
+                add_province_modifier = {
+                    name = colonial_exploitation
+                    duration = 1095
+                }
+            }
+        }
+        INO = { add_accepted_culture = moluccan }
+        state_scope = {
+            any_owned = {
+                limit = { is_core = INO NOT = { province_id = 1446 } }
+                remove_core = JAV
+                remove_core = DJA
+                remove_core = SAK
+                remove_core = ATJ
+                remove_core = BAL
+                remove_core = SLW
+                remove_core = MAL
+                remove_core = KLM
+                remove_core = LAN
+                remove_core = PNK
+                remove_core = KTI
+                remove_core = SUL
+                remove_core = BRU
+            }
+        }
+    }
+}
+
+province_event = {
+    id = 97132
+    title = "EVTNAME98800"
+    desc = "EVTDESC97130"
+
+    trigger = {
+        OR = {
+            region = NET_1451 #West New Guinea
+            region = AST_2528 #Southeast New Guinea
+            region = GER_2530 #Northeast New Guinea
+        }
+        owned_by = THIS
+        controlled_by = THIS
+        any_neighbor_province = {
+            is_core = INO
+        }
+        owner = {
+            civilized = yes
+            NOT = { is_culture_group = southeast_asian }
+        }
+        OR = {
+            AND = {
+                owner = { owns = 1413 }
+                INO = { exists = no }
+            }
+            INO = {
+                vassal_of = THIS
+                is_culture_group = THIS
+            }
+        }
+        NOT = {
+            is_core = INO
+        }
+    }
+
+    mean_time_to_happen = {
+        months = 60
+    }
+
+    option = {
+        name = "EVT97130OPTA"
+        state_scope = {
+            any_owned = {
+                limit = {
+                    NOT = { is_core = INO }
+                }
+                add_core = INO
+                any_pop = { militancy = -3 }
+                add_province_modifier = {
+                    name = colonial_exploitation
+                    duration = 1095
+                }
+            }
+        }
+        INO = { add_accepted_culture = melanesian }
+        state_scope = {
+            any_owned = {
+                limit = { is_core = INO NOT = { province_id = 1446 } }
+                remove_core = JAV
+                remove_core = DJA
+                remove_core = SAK
+                remove_core = ATJ
+                remove_core = BAL
+                remove_core = SLW
+                remove_core = MAL
+                remove_core = KLM
+                remove_core = LAN
+                remove_core = PNK
+                remove_core = KTI
+                remove_core = SUL
+                remove_core = BRU
+            }
+        }
+    }
+}
+
+# Unification of Lan Xang (Laos)
+country_event = {
+    id = 97120
+    title = "EVTNAME97120"
+    desc = "EVTDESC97120"
+    picture = "Celebration"
+
+    is_triggered_only = yes
+
+    option = {
+        name = "EVT97120OPTA"
+        any_owned = { limit = { is_core = THIS } add_core = LXA remove_core = THIS }
+        FROM = { inherit = THIS }
+        ai_chance = {
+            factor = 50
+            modifier = {
+                factor = 1.5
+                in_sphere = FROM
+            }
+            modifier = {
+                factor = 1.5
+                relation = {
+                    who = FROM
+                    value = 100
+                }
+            }
+            modifier = {
+                factor = 1.5
+                relation = {
+                    who = FROM
+                    value = 175
+                }
+            }
+            modifier = {
+                factor = 1.5
+                alliance_with = FROM
+            }
+            modifier = {
+                factor = 2
+                government = fascist_dictatorship
+                FROM = {
+                    government = fascist_dictatorship
+                }
+            }
+            modifier = {
+                factor = 2
+                government = proletarian_dictatorship
+                FROM = {
+                    government = proletarian_dictatorship
+                }
+            }
+            modifier = {
+                factor = 3
+                vassal_of = FROM
+            }
+        }
+    }
+
+    option = {
+        name = "EVT97120OPTB"
+        prestige = 1
+        relation = {
+            who = FROM
+            value = -100
+        }
+        leave_alliance = FROM
+        ai_chance = {
+            factor = 50
+            modifier = {
+                factor = 1.5
+                NOT = {
+                    relation = {
+                        who = FROM
+                        value = -100
+                    }
+                }
+            }
+            modifier = {
+                factor = 1.5
+                NOT = {
+                    relation = {
+                        who = FROM
+                        value = -175
+                    }
+                }
+            }
+            modifier = {
+                factor = 10
+                government = fascist_dictatorship
+                FROM = {
+                    government = proletarian_dictatorship
+                }
+            }
+            modifier = {
+                factor = 10
+                government = proletarian_dictatorship
+                FROM = {
+                    government = fascist_dictatorship
+                }
+            }
+        }
+    }
+}
+
+#Anglo-Siamese Treaty of 1909
+country_event = {
+    id = 97122
+    title = "EVTNAME97122"
+    desc = "EVTDESC97122"
+    picture = "lan_xang"
+
+    trigger = {
+        owns = 2575
+        owns = 1390
+        nationalism_n_imperialism = 1
+        SIA = {
+            exists = yes
+            owns = 1391
+            owns = 1389
+        }
+        has_global_flag = berlin_conference
+        NOT = { tag = SIA }
+    }
+
+    fire_only_once = yes
+    mean_time_to_happen = { months = 3 }
+
+    option = {
+        name = "EVT97122OPTA"
+        SIA = { country_event = 97123 }
+        ai_chance = { factor = 100 }
+    }
+
+    option = {
+        name = "EVT97122OPTB"
+        ai_chance = { factor = 0 }
+    }
+}
+
+#Anglo-Siamese Treaty of 1909 2/2
+country_event = {
+    id = 97123
+    title = "EVTNAME97123"
+    desc = "EVTDESC97123"
+    picture = "lan_xang"
+
+    is_triggered_only = yes
+
+    option = {
+        name = "EVT97123OPTA"
+        any_pop = { militancy = 4 }
+        random_owned = {
+            limit = {
+                owner = { NOT = { has_global_flag = malaya_formed } }
+            }
+            owner = {
+                1389 = { secede_province = FROM remove_core = THIS remove_core = JOH add_core = PRK }
+                1388 = { remove_core = THIS remove_core = JOH add_core = PRK }
+                1391 = { secede_province = FROM remove_core = THIS remove_core = JOH add_core = PHG }
+                1390 = { remove_core = THIS }
+                2575 = { remove_core = THIS }
+            }
+        }
+
+        random_owned = {
+            limit = {
+                owner = { has_global_flag = malaya_formed }
+            }
+            owner = {
+                1389 = { secede_province = FROM remove_core = THIS remove_core = JOH add_core = MLY }
+                1388 = { remove_core = THIS remove_core = JOH add_core = MLY }
+                1391 = { secede_province = FROM remove_core = THIS remove_core = JOH add_core = MLY }
+                1390 = { remove_core = THIS }
+                2575 = { remove_core = THIS }
+            }
+        }
+
+        relation = { who = FROM value = 150 }
+        FROM = { diplomatic_influence = { who = THIS value = 75 } }
+        ai_chance = {
+            factor = 0.9
+            modifier = {
+                factor = 0.6
+                NOT = { in_sphere = FROM }
+                part_of_sphere = yes
+            }
+            modifier = {
+                factor = 200
+                in_sphere = FROM
+            }
+        }
+    }
+
+    option = {
+        name = "EVT97123OPTB"
+        FROM = {
+            diplomatic_influence = { who = THIS value = -400 }
+            relation = { who = THIS value = -150 }
+            leave_alliance = THIS
+            release_vassal = THIS
+            casus_belli = {
+                target = THIS
+                type = demand_concession_BC_casus_belli
+                months = 60
+            }
+            casus_belli = {
+                target = THIS
+                type = acquire_state
+                months = 60
+            }
+            casus_belli = {
+                target = THIS
+                type = cut_down_to_size
+                months = 60
+            }
+            casus_belli = {
+                target = THIS
+                type = humiliate
+                months = 60
+            }
+        }
+        random_owned = {
+            limit = { owner = { is_greater_power = no civilized = no } }
+            FROM = {
+                war = {
+                target = THIS
+                attacker_goal = { casus_belli = acquire_state state_province_id = 1391 }
+                defender_goal = { casus_belli = status_quo }
+                }
+            }
+        }
+        ai_chance = {
+            factor = 0.05
+            modifier = {
+                factor = 1.5
+                civilized = yes
+                }
+            }
+        }
+    }
+
+
+#End of the Padri War
+country_event = {
+    id = 971204
+    title = "EVTNAME971204"
+    desc = "EVTDESC971204"
+    picture = "aceh_jihad"
+
+    trigger = {
+        tag = ENG
+        truce_with = ATJ
+        NOT = { year = 1845 }
+        ATJ = { has_recently_lost_war = yes }
+    }
+
+    fire_only_once = yes
+    mean_time_to_happen = { months = 1 }
+
+    option = {
+        name = "EVT971204OPTA"
+        prestige = -5
+        1408 = { secede_province = ENG remove_core = ATJ }
+        1411 = { secede_province = ENG remove_core = ATJ }
+    }
+}
+
+#Integration of the Malay Minors 1/2
+country_event = {
+    id = 971205
+    title = "EVTNAME971205"
+    desc = "EVTDESC971205"
+    picture = "malay_sultan"
+
+    trigger = {
+        ai = yes
+        exists = yes
+        OR = {
+            part_of_sphere = yes
+            any_neighbor_country = {
+                is_greater_power = yes
+                relation = { who = THIS value = 25 }
+            }
+        }
+        OR = {
+            tag = ATJ
+			tag = SAK
+            tag = BRU
+            tag = MLC
+            tag = KTI
+            tag = SLW
+            tag = JAV
+        }
+    }
+
+    mean_time_to_happen = {
+        months = 60
+
+        modifier = {
+            factor = 0.5
+            sphere_owner = { revolution_n_counterrevolution = 1 }
+        }
+
+        modifier = {
+            factor = 0.8
+            sphere_owner = { nationalism_n_imperialism = 1 }
+        }
+
+        modifier = {
+            factor = 0.9
+            average_militancy = 2
+        }
+
+        modifier = {
+            factor = 0.8
+            average_militancy = 3
+        }
+
+        modifier = {
+            factor = 0.7
+            average_militancy = 4
+        }
+
+        modifier = {
+            factor = 0.6
+            average_militancy = 5
+        }
+
+        modifier = {
+            factor = 0.5
+            average_militancy = 6
+        }
+
+        modifier = {
+            factor = 0.4
+            average_militancy = 7
+        }
+
+        modifier = {
+            factor = 0.3
+            average_militancy = 8
+        }
+
+        modifier = {
+            factor = 0.2
+            average_militancy = 9
+        }
+    }
+
+    option = {
+        name = "EVT971205OPTA"
+        random_owned = {
+            limit = { owner = { part_of_sphere = yes } }
+            owner = { sphere_owner = { country_event = 971206 } }
+        }
+
+        random_owned = {
+            limit = {
+                owner = {
+                    part_of_sphere = no
+                    any_neighbor_country = {
+                        is_greater_power = yes
+                        relation = { who = THIS value = 25 }
+                    }
+                }
+            }
+            owner = {
+                random_country = {
+                    limit = {
+                        is_greater_power = yes
+                        neighbour = THIS
+                    }
+                    country_event = 971206
+                }
+            }
+        }
+    }
+}
+
+#Integration of the Malay Minors 2/2
+country_event = {
+    id = 971206
+    title = "EVTNAME971206"
+    desc = "EVTDESC971206"
+    picture = "malay_sultan"
+
+    is_triggered_only = yes
+
+    option = {
+        name = "EVT971206OPTA"
+        badboy = 0.5
+        inherit = FROM
+
+        ai_chance = {
+            factor = 90
+            modifier = { factor = 0 badboy = 0.96 }
+        }
+    }
+
+    option = {
+        name = "EVT971206OPTB"
+        prestige = -1
+        badboy = -0.25
+        FROM = { set_country_flag = malay_will_not_be_integrated }
+
+        ai_chance = {
+            factor = 10
+            modifier = {
+                factor = 0
+                NOT = { badboy = 0.75 }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds relevant flavor events from HPM. Additionally fixes the Indonesian Minor annexation events and the Doctrine of Lapse events. Also adds 5 infamy per use of Doctrine of Lapse to counter the free Great Game CB.