### PR TITLE
Restored moving sounds to cavalry units

### DIFF
--- a/MMM/units/cavalry.txt
+++ b/MMM/units/cavalry.txt
@@ -1,0 +1,45 @@
+cavalry = {
+	icon = 2
+	
+	type = land
+	sprite = Cavalry
+	active = yes
+	unit_type = cavalry
+	floating_flag = yes
+	
+	#Avatar
+	sprite_mount = GenericMount
+	sprite_mount_attach_node = Saddle_Node
+	move_sound = cavalry_move
+	select_sound = cavalry_selected
+	
+	#Core Abilities
+	priority = 25
+	max_strength = 3
+	default_organisation = 20
+	maximum_speed = 5.00
+	weighted_value = 4.0
+
+
+	#Building Costs
+	build_time = 120
+	build_cost = {
+		wool = 20
+		wine = 10
+	}
+	
+	supply_consumption = 1.0
+	supply_cost = {
+		wool = 0.2
+	}
+	
+
+	#Land Abilties
+	reconnaissance = 1
+	attack = 3
+	defence = 1
+	discipline = 1.0
+	support = 0.0
+	maneuver = 2
+	
+}

--- a/MMM/units/cuirassier.txt
+++ b/MMM/units/cuirassier.txt
@@ -1,0 +1,50 @@
+cuirassier = {
+	icon = 13
+	
+	type = land
+	sprite = Cuirassier
+	active = no
+	unit_type = cavalry
+	
+	#Avatar
+	sprite_override = Cavalry
+	sprite_mount = GenericMount
+	sprite_mount_attach_node = Saddle_Node
+	floating_flag = yes
+	move_sound = cavalry_move
+	select_sound = cavalry_selected
+	
+	#Core Abilities
+	priority = 30
+	max_strength = 3
+	default_organisation = 30
+	maximum_speed = 5.00
+	weighted_value = 8.0
+
+
+	#Building Costs
+	build_time = 120
+	build_cost = {
+		small_arms = 10
+		canned_food = 10
+		steel = 20
+	}
+	
+	supply_consumption = 1.0
+	supply_cost = {
+		small_arms = 0.015 # 0.008
+		ammunition = 0.05 # 0
+		canned_food = 0.07 #0.08
+		#steel = 0.1 # 0.008
+	}
+	
+
+	#Land Abilties
+	reconnaissance = 0
+	attack = 6
+	defence = 4
+	discipline = 1.0
+	support = 0.0
+	maneuver = 2
+	
+}

--- a/MMM/units/dragoon.txt
+++ b/MMM/units/dragoon.txt
@@ -1,0 +1,49 @@
+dragoon = {
+	icon = 14
+	
+	type = land
+	sprite = Dragoon
+	active = no
+	unit_type = cavalry
+	
+	#Avatar
+	sprite_override = Cavalry
+	sprite_mount = GenericMount
+	sprite_mount_attach_node = Saddle_Node
+	floating_flag = yes
+	move_sound = cavalry_move
+	select_sound = cavalry_selected
+	
+	#Core Abilities
+	priority = 35
+	max_strength = 3
+	default_organisation = 30
+	maximum_speed = 5.00
+	weighted_value = 6.0
+
+
+	#Building Costs
+	build_time = 150
+	build_cost = {
+		small_arms = 10
+		canned_food = 10
+		wine = 10
+	}
+	
+	supply_consumption = 1.0
+	supply_cost = {
+		small_arms = 0.012 #0.008
+		ammunition = 0.075 # 0
+		canned_food = 0.07 #0.08
+	}
+	
+
+	#Land Abilties
+	reconnaissance = 1
+	attack = 4
+	defence = 3
+	discipline = 1.0
+	support = 0.0
+	maneuver = 3
+	
+}

--- a/MMM/units/hussar.txt
+++ b/MMM/units/hussar.txt
@@ -1,0 +1,49 @@
+hussar = {
+	icon = 15
+	
+	type = land
+	sprite = Hussar
+	active = no
+	unit_type = cavalry
+	floating_flag = yes
+	
+	#Avatar
+	sprite_override = Cavalry
+	sprite_mount = GenericMount
+	sprite_mount_attach_node = Saddle_Node
+	move_sound = cavalry_move
+	select_sound = cavalry_selected
+	
+	#Core Abilities
+	priority = 40
+	max_strength = 3
+	default_organisation = 30
+	maximum_speed = 6.00
+	weighted_value = 7.0
+
+
+	#Building Costs
+	build_time = 120
+	build_cost = {
+		small_arms = 10
+		canned_food = 10
+		luxury_clothes = 5
+	}
+	
+	supply_consumption = 1.0
+	supply_cost = {
+		small_arms = 0.015 #0.01
+		ammunition = 0.075 #0
+		canned_food = 0.08 #0.08
+	}
+	
+
+	#Land Abilties
+	reconnaissance = 2
+	attack = 3
+	defence = 3
+	discipline = 1.0
+	support = 0.0
+	maneuver = 4
+	
+}


### PR DESCRIPTION
Added  `move_sound = cavalry_move` and `select_sound = cavalry_selected` back into the vanilla cavalry unit files and thew them into the units folder! 
