### PR TITLE
Updated Prussian Revolution Event

### DIFF
--- a/MMM/events/Megamp German Revolution.txt
+++ b/MMM/events/Megamp German Revolution.txt
@@ -1,7 +1,7 @@
 country_event = {
     id = 55002
     title = "Revolution in Prussia"
-    desc = ""
+    desc = "Revolution in Berlin ! As violent crowds of began converging on the royal palace, The King, fearing for his life, abdicated and fled to England in disguise. A new liberal regime was proclaimed, a Republic for the people of Germany"
     picture = "prussian_constitution"
 
     trigger = {
@@ -86,8 +86,8 @@ country_event = {
     }
 
     option = {
-        name = "Freiheit, Gleichheit, Bruderlichkeit !"
-        prestige = -25
+        name = "Unity and justice and freedom for the German fatherland!"
+        prestige = -15
         any_owned = {
             remove_province_modifier = liberal_agitation
         }
@@ -151,18 +151,6 @@ country_event = {
             dominant_issue = { factor = 0.20 value = jingoism }
         }
         any_pop = {
-            limit = {
-                strata = poor
-                is_culture_group = germanic
-                location = { is_core = PRU }
-            }
-            ideology = { factor = 0.2 value = conservative }
-            dominant_issue = { factor = 0.10 value = jingoism }
-        }
-        any_pop = {
-            limit = {
-                location = { is_core = PRU }
-            }
             scaled_militancy = {
                 ideology = reactionary
                 factor = 4
@@ -186,7 +174,6 @@ country_event = {
                     has_country_flag = liberal_revolution_in_progress
                     has_country_modifier = springtime_of_nations
                 }
-                NOT = { is_culture_group = scandinavian }
                 NOT = { government = democracy }
                 NOT = { government = hms_government }
             }
@@ -206,15 +193,15 @@ country_event = {
             all_core = { add_core = PRU }
             country_event = 11101
         }
-
-        any_country = {
-            limit = {
-                NOT = { is_culture_group = germanic }
-                vassal_of = THIS
-            }
+        
+        BOH = {
             country_event = 55003
         }
-        
+
+        BAV = {
+            country_event = 55015
+        }
+
         any_country = {
             limit = {
                 alliance_with = THIS
@@ -232,9 +219,9 @@ country_event = {
 
 country_event = {
     id = 55003
-    name = "King of Prussia abdicates"
-    desc = ""
-    picture = "Celebration"
+    name = "Revolution in Prussia"
+    desc = "The King of Prussia has abdicated, and a liberal regime was proclaimed, a Republic for the German people"
+    picture = "prussian_constitution"
 
     is_triggered_only = yes
 
@@ -248,5 +235,39 @@ country_event = {
         relation = { who = FROM value = -150 }
         leave_alliance = FROM
         end_military_access = FROM
+    }
+}
+
+country_event = {
+    id = 55015
+    name = "Liberal Revolution in Prussia"
+    desc = "The King of Prussia has abdicated, and a liberal regime was proclaimed, a Republic for the German people"
+    picture = "prussian_constitution"
+
+    is_triggered_only = yes
+
+    option = {
+        name = "The King will still rule in $COUNTRY$"
+        FROM = {
+            release_vassal = THIS
+            end_military_access = THIS
+
+        }
+        relation = { who = FROM value = -150 }
+        leave_alliance = FROM
+        end_military_access = FROM
+
+        any_pop = {
+            limit = {
+                is_culture_group = germanic
+            }
+            ideology = { factor = 0.5 value = liberal }
+        }
+        any_pop {
+            scaled_militancy = {
+                ideology = liberal
+                factor = 7
+            }
+        }
     }
 }


### PR DESCRIPTION
Removed some bloat effects carried out from the french HPM event.
Lessened the prestige loss -25 to -15
Added flavour event for Bavaria that adds a large amount of militancy to liberal POPs , aswell as turn a large part of the POPs to liberalism.